### PR TITLE
[go] add Flush method to loggingResponseWriter for better response ha…

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -42,6 +42,12 @@ func (lrw *loggingResponseWriter) WriteHeader(code int) {
 	lrw.ResponseWriter.WriteHeader(code)
 }
 
+func (lrw *loggingResponseWriter) Flush() {
+	if flusher, ok := lrw.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
 func statusCodeColor(statusCode int) string {
 	switch {
 	case statusCode >= 200 && statusCode < 300:


### PR DESCRIPTION
This pull request adds a new method to the `loggingResponseWriter` type to improve HTTP response handling. The main change is the implementation of the `Flush()` method, which ensures that if the underlying `ResponseWriter` supports flushing, it will be properly called.

HTTP response handling:

* Added a `Flush()` method to `loggingResponseWriter` that delegates to the underlying `ResponseWriter`'s `Flush()` method if it implements the `http.Flusher` interface.

Existing error when running http `GET /debug/send-command/

```
david@hydra velocity.report % ./app-local -dev
2025/08/26 18:28:18 Writing mock serial port received input at ./mock_serial_port3108238662
2025/08/26 18:28:18 initialised device &{%!s(*serialmux.MockSerialPort=&{0x1400009cfc0 0x140001122c8}) map[] {{} {%!s(int32=0) %!s(uint32=0)}} {{} {%!s(int32=0) %!s(uint32=0)}} %!s(bool=false) {{} {%!s(int32=0) %!s(uint32=0)}}}
2025/08/26 18:28:39 http: panic serving [::1]:54792: interface conversion: *api.loggingResponseWriter is not http.Flusher: missing method Flush
goroutine 65 [running]:
net/http.(*conn).serve.func1()
        /opt/homebrew/opt/go/libexec/src/net/http/server.go:1947 +0xb0
panic({0x105090fa0?, 0x14000980540?})
        /opt/homebrew/opt/go/libexec/src/runtime/panic.go:792 +0x124
github.com/banshee-data/velocity.report/internal/serialmux.(*SerialMux[...]).AttachAdminRoutes.func3(0x140009823c0)
        /Users/david/code/velocity.report/internal/serialmux/serialmux.go:284 +0x428
net/http.HandlerFunc.ServeHTTP(0x14000980480?, {0x10513f2f8?, 0x1400099c078?}, 0x104f09e07?)
        /opt/homebrew/opt/go/libexec/src/net/http/server.go:2294 +0x38
tailscale.com/tsweb.(*DebugHandler).handle.debugBrowserHeaderHandler.func1({0x10513f2f8, 0x1400099c078}, 0x140009823c0)
        /Users/david/go/pkg/mod/tailscale.com@v1.87.0-pre.0.20250728175739-4df02bbb486d/tsweb/debug.go:191 +0x84
net/http.HandlerFunc.ServeHTTP(0x140009823c0?, {0x10513f2f8?, 0x1400099c078?}, 0x104843d38?)
        /opt/homebrew/opt/go/libexec/src/net/http/server.go:2294 +0x38
tailscale.com/tsweb.(*DebugHandler).handle.Protected.func2({0x10513f2f8, 0x1400099c078}, 0x140009823c0)
        /Users/david/go/pkg/mod/tailscale.com@v1.87.0-pre.0.20250728175739-4df02bbb486d/tsweb/tsweb.go:132 +0xfc
net/http.HandlerFunc.ServeHTTP(0x14000146180?, {0x10513f2f8?, 0x1400099c078?}, 0x104e92a04?)
        /opt/homebrew/opt/go/libexec/src/net/http/server.go:2294 +0x38
net/http.(*ServeMux).ServeHTTP(0x1400003ba68?, {0x10513f2f8, 0x1400099c078}, 0x140009823c0)
        /opt/homebrew/opt/go/libexec/src/net/http/server.go:2822 +0x1b4
main.main.func3.LoggingMiddleware.4({0x10513f418, 0x140009981c0}, 0x140009823c0)
        /Users/david/code/velocity.report/internal/api/server.go:65 +0xac
net/http.HandlerFunc.ServeHTTP(0x140004fc120?, {0x10513f418?, 0x140009981c0?}, 0x1400003bb60?)
        /opt/homebrew/opt/go/libexec/src/net/http/server.go:2294 +0x38
net/http.serverHandler.ServeHTTP({0x1400016f1a0?}, {0x10513f418?, 0x140009981c0?}, 0x6?)
        /opt/homebrew/opt/go/libexec/src/net/http/server.go:3301 +0xbc
net/http.(*conn).serve(0x140006da240, {0x10513fbe8, 0x140000b6990})
        /opt/homebrew/opt/go/libexec/src/net/http/server.go:2102 +0x52c
created by net/http.(*Server).Serve in goroutine 10
        /opt/homebrew/opt/go/libexec/src/net/http/server.go:3454 +0x3d8
2025/08/26 18:28:39 http: panic serving [::1]:54790: interface conversion: *api.loggingResponseWriter is not http.Flusher: missing method Flush
goroutine 11 [running]:
net/http.(*conn).serve.func1()
        /opt/homebrew/opt/go/libexec/src/net/http/server.go:1947 +0xb0
panic({0x105090fa0?, 0x14000906270?})
[...]
```

after: 

```
david@hydra velocity.report % make build-local;./app-local -dev                                                     
go build -o app-local ./cmd/radar
2025/08/26 18:30:21 Writing mock serial port received input at ./mock_serial_port723763037
2025/08/26 18:30:21 initialised device &{%!s(*serialmux.MockSerialPort=&{0x1400007f0e0 0x14000068350}) map[] {{} {%!s(int32=0) %!s(uint32=0)}} {{} {%!s(int32=0) %!s(uint32=0)}} %!s(bool=false) {{} {%!s(int32=0) %!s(uint32=0)}}}
2025/08/26 18:30:23 [200] GET /debug/ 0.13675ms
2025/08/26 18:30:23 [200] GET /favicon.ico 3.187041ms
2025/08/26 18:30:27 [200] GET /debug/send-command 0.783875ms
2025/08/26 18:30:27 [200] GET /debug/tail.js 0.082833ms
2025/08/26 18:30:36 [200] POST /debug/send-command-api 0.379709ms
```
