### PR TITLE
[go] fix RadarObjects query, migration & vscode settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "inferrinizzard.prettier-sql-vscode"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,26 @@
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "explicit"
+  },
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "Prettier-SQL.commaPosition": "before",
+  "Prettier-SQL.expressionWidth": 70,
+  "Prettier-SQL.indentStyle": "tabularRight",
+  "Prettier-SQL.keywordCase": "upper",
+  "Prettier-SQL.newlineBeforeSemicolon": true,
+  "Prettier-SQL.SQLFlavourOverride": "sqlite",
+  // Go settings
+  "go.lintOnSave": "file",
+  "go.lintTool": "golangci-lint",
+  "go.formatTool": "goimports",
+  "go.useLanguageServer": true,
+  "[go]": {
+    "editor.defaultFormatter": "golang.go",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "always"
+    }
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": "explicit"
+    "source.organizeImports": "always"
   },
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,

--- a/data/migrations/20250826_rename_tables_column.sql
+++ b/data/migrations/20250826_rename_tables_column.sql
@@ -1,0 +1,17 @@
+-- To apply this migration, run:
+--   sqlite3 sensor_data.db < data/migrations/20250826_rename_tables_column.sql
+    ALTER TABLE data
+RENAME TO radar_data
+;
+
+    ALTER TABLE log
+RENAME TO radar_command_log
+;
+
+    ALTER TABLE commands
+RENAME TO radar_commands
+;
+
+    ALTER TABLE radar_objects
+   RENAME COLUMN length TO length_m
+;

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -99,7 +99,7 @@ func (e *RadarObject) String() string {
 func (db *DB) RadarObjects() ([]RadarObject, error) {
 	rows, err := db.Query(`SELECT classifier, start_time, end_time, delta_time_ms, max_speed, min_speed,
 			speed_change, max_magnitude, avg_magnitude, total_frames,
-			frames_per_mps, length FROM radar_objects ORDER BY write_timestamp DESC LIMIT 100`)
+			frames_per_mps, length_m FROM radar_objects ORDER BY write_timestamp DESC LIMIT 100`)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -43,7 +43,7 @@ func NewDB(path string) (*DB, error) {
 		return nil, err
 	}
 
-	log.Println("Successfully created database schema")
+	log.Println("ran database initialisation script")
 
 	return &DB{db}, nil
 }


### PR DESCRIPTION
This pull request introduces workspace configuration improvements for VS Code and a minor database schema update. The main changes include adding recommended extensions and settings for consistent formatting, and updating a database column name for clarity.

**VS Code configuration enhancements:**

* Added `.vscode/extensions.json` to recommend the `prettier-sql-vscode` extension for improved SQL formatting.
* Added `.vscode/settings.json` with formatting, whitespace, and Go development settings to enforce consistent code style and streamline development workflows.

**Database schema update:**

* Renamed the `length` column to `length_m` in the SQL query within `internal/db/db.go` to clarify units (meters).
This pull request introduces editor configuration improvements and a minor database query update. The main focus is on enhancing the developer experience by standardizing formatting and linting settings for both SQL and Go code, as well as updating a column reference in a database query.

Editor and tooling configuration:

* Added `.vscode/extensions.json` to recommend the `prettier-sql-vscode` extension for consistent SQL formatting.
* Updated `.vscode/settings.json` to enforce formatting on save, organize imports, trim trailing whitespace, and insert a final newline. Added detailed configuration for the Prettier-SQL extension (such as keyword case and indentation), and set up Go-specific linting and formatting tools.

Database query update:

* In `internal/db/db.go`, changed the selected column from `length` to `length_m` in the SQL query within the `RadarObjects` method to match the current database schema or naming conventions.