### PR TITLE
[go] fix, bundle prod web assets

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -4,3 +4,6 @@ import "embed"
 
 //go:embed static/*
 var StaticFiles embed.FS
+
+//go:embed web/build/*
+var WebBuildFiles embed.FS

--- a/cmd/radar/radar.go
+++ b/cmd/radar/radar.go
@@ -242,7 +242,7 @@ func main() {
 					}
 				} else {
 					// Production mode: serve from embedded filesystem
-					embedPath := "web/build/" + strings.TrimPrefix(requestedPath, "/")
+					embedPath := filepath.Join("web/build", strings.TrimPrefix(requestedPath, "/"))
 					if content, err := radar.WebBuildFiles.ReadFile(embedPath); err == nil {
 						serveContent(content, requestedPath)
 						return true


### PR DESCRIPTION
Failing with error:

```
Aug 27 18:13:07 radar systemd[1]: Started velocity-report.service - Radar Monitor Service.
Aug 27 18:13:07 radar go-sensor[147346]: 2025/08/27 18:13:07 initialised device &{%!s(*serial.unixPort=&{3 -1 {{{} {0 0}} 0 0 {{} 0} {{} 0}} 0x4000026300 1}) map[] {{} {%!s(int32=0) %!s(uint32=0)}} {{} {%!s(int32=0) %!s(uint32=0)}} %!s(bool=false) {{} {%!s(int32=0) %!s(uint32=0)}}}
Aug 27 18:13:07 radar go-sensor[147346]: 2025/08/27 18:13:07 ran database initialisation script
Aug 27 18:13:07 radar go-sensor[147346]: 2025/08/27 18:13:07 Build directory ./web/build does not exist. Run 'cd web && pnpm run build' first.
Aug 27 18:13:07 radar systemd[1]: velocity-report.service: Main process exited, code=exited, status=1/FAILURE
Aug 27 18:13:07 radar systemd[1]: velocity-report.service: Failed with result 'exit-code'.
Aug 27 18:13:12 radar systemd[1]: velocity-report.service: Scheduled restart job, restart counter is at 1.
Aug 27 18:13:12 radar systemd[1]: Stopped velocity-report.service - Radar Monitor Service.
```

This pull request refactors how the frontend assets are served in both development and production modes, improving the flexibility and reliability of serving the SvelteKit frontend. The main change is the introduction of a unified handler that serves frontend files from the filesystem in development and from embedded assets in production, with robust handling for single-page application (SPA) routing and prerendered routes.

Frontend asset serving improvements:

* Added embedding of the `web/build` directory into the binary using Go's `embed` package, allowing frontend assets to be served from memory in production (`assets.go`).
* Refactored the `/app/` route handler to:
  * Serve files from the filesystem in development mode, and from the embedded filesystem in production.
  * Attempt to serve the requested file, then try the `.html` version for prerendered routes, and finally fall back to `index.html` for SPA routing.
  * Return a 404 if no suitable file is found (`cmd/radar/radar.go`).
* Limited the build directory existence check to development mode only, avoiding unnecessary checks in production (`cmd/radar/radar.go`).
