### PR TITLE
[go] internal/lidarr: use os.TempDir for export destination

### DIFF
--- a/internal/lidar/frame_builder.go
+++ b/internal/lidar/frame_builder.go
@@ -3,6 +3,7 @@ package lidar
 import (
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -489,7 +490,7 @@ func (fb *FrameBuilder) finalizeFrame(frame *LiDARFrame) {
 	if fb.exportNextFrameASC {
 		path := fb.exportNextFramePath
 		if path == "" {
-			path = fmt.Sprintf("/tmp/lidar/next_frame_%s_%d.asc", frame.SensorID, time.Now().Unix())
+			path = filepath.Join(os.TempDir(), fmt.Sprintf("next_frame_%s_%d.asc", frame.SensorID, time.Now().Unix()))
 		}
 		_ = exportFrameToASC(frame)
 		log.Printf("[FrameBuilder] Exported next frame for sensor %s to %s", frame.SensorID, path)
@@ -606,7 +607,7 @@ func exportFrameToASC(frame *LiDARFrame) error {
 	}
 
 	filename := fmt.Sprintf("lidar_frame_%s_%d.asc", frame.SensorID, frame.StartTimestamp.Unix())
-	filePath := filepath.Join("/tmp/lidar", filename)
+	filePath := filepath.Join(os.TempDir(), filename)
 
 	// Convert LiDARFrame points to PointASC
 	ascPoints := make([]PointASC, len(frame.Points))

--- a/internal/lidar/frame_builder.go
+++ b/internal/lidar/frame_builder.go
@@ -492,8 +492,11 @@ func (fb *FrameBuilder) finalizeFrame(frame *LiDARFrame) {
 		if path == "" {
 			path = filepath.Join(os.TempDir(), fmt.Sprintf("next_frame_%s_%d.asc", frame.SensorID, time.Now().Unix()))
 		}
-		_ = exportFrameToASC(frame)
-		log.Printf("[FrameBuilder] Exported next frame for sensor %s to %s", frame.SensorID, path)
+		if err := exportFrameToASC(frame); err != nil {
+			log.Printf("[FrameBuilder] Failed to export next frame for sensor %s to %s: %v", frame.SensorID, path, err)
+		} else {
+			log.Printf("[FrameBuilder] Exported next frame for sensor %s to %s", frame.SensorID, path)
+		}
 		fb.exportNextFrameASC = false
 		fb.exportNextFramePath = ""
 	}

--- a/internal/lidar/monitor/webserver.go
+++ b/internal/lidar/monitor/webserver.go
@@ -12,6 +12,8 @@ import (
 	"html/template"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/banshee-data/velocity.report/internal/db"
@@ -276,7 +278,7 @@ func (ws *WebServer) handleExportSnapshotASC(w http.ResponseWriter, r *http.Requ
 	}
 
 	if outPath == "" {
-		outPath = fmt.Sprintf("/tmp/lidar/bg_snapshot_%s_%d.asc", sensorID, snap.TakenUnixNanos)
+		outPath = filepath.Join(os.TempDir(), fmt.Sprintf("bg_snapshot_%s_%d.asc", sensorID, snap.TakenUnixNanos))
 	}
 
 	if err := lidar.ExportBgSnapshotToASC(snap, outPath, elevs); err != nil {


### PR DESCRIPTION
Use platform-local tempdir vs presuming that /tmp/lidar is writeable.