### PR TITLE
Parameterize transit rollup model version in stats query

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -247,6 +247,14 @@ func (s *Server) showRadarObjectStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	modelVersion := ""
+	if dataSource == "radar_data_transits" {
+		modelVersion = r.URL.Query().Get("model_version")
+		if modelVersion == "" {
+			modelVersion = "rebuild-full"
+		}
+	}
+
 	// Optional histogram computation parameters
 	computeHist := false
 	if ch := r.URL.Query().Get("compute_histogram"); ch != "" {
@@ -281,7 +289,7 @@ func (s *Server) showRadarObjectStats(w http.ResponseWriter, r *http.Request) {
 		maxMPS = units.ConvertToMPS(histMax, displayUnits)
 	}
 
-	result, dbErr := s.db.RadarObjectRollupRange(startUnix, endUnix, groupSeconds, minSpeedMPS, dataSource, bucketSizeMPS, maxMPS)
+	result, dbErr := s.db.RadarObjectRollupRange(startUnix, endUnix, groupSeconds, minSpeedMPS, dataSource, modelVersion, bucketSizeMPS, maxMPS)
 	if dbErr != nil {
 		s.writeJSONError(w, http.StatusInternalServerError,
 			fmt.Sprintf("Failed to retrieve radar stats: %v", dbErr))

--- a/internal/db/db_rollup_test.go
+++ b/internal/db/db_rollup_test.go
@@ -46,7 +46,7 @@ func TestRadarObjectRollupRange_MinSpeed(t *testing.T) {
 	// Query rollup with minSpeed = 2.0 m/s (should include 3.0 and 6.0)
 	start := now - 10
 	end := now + 1000
-	result, err := dbinst.RadarObjectRollupRange(start, end, 300, 2.0, "radar_objects", 0, 0)
+	result, err := dbinst.RadarObjectRollupRange(start, end, 300, 2.0, "radar_objects", "", 0, 0)
 	if err != nil {
 		t.Fatalf("RadarObjectRollupRange failed: %v", err)
 	}

--- a/internal/report/query_data/README.md
+++ b/internal/report/query_data/README.md
@@ -45,6 +45,13 @@ python get_stats.py --group 1h --units mph --timezone US/Pacific \\
     2025-06-02 2025-06-04
 ```
 
+To query transit rollups, provide the data source and (optionally) override the model version:
+
+```bash
+python get_stats.py --source radar_data_transits --model-version rebuild-full \\
+    2025-06-02 2025-06-04
+```
+
 ### As a Library
 
 ```python

--- a/internal/report/query_data/api_client.py
+++ b/internal/report/query_data/api_client.py
@@ -38,6 +38,7 @@ class RadarStatsClient:
         group: str = "1h",
         units: str = "mph",
         source: str = "radar_objects",
+        model_version: Optional[str] = None,
         timezone: Optional[str] = None,
         min_speed: Optional[float] = None,
         compute_histogram: bool = False,
@@ -52,6 +53,7 @@ class RadarStatsClient:
             group: Aggregation period (15m, 30m, 1h, etc.)
             units: Speed units (mph, kph, etc.)
             source: Data source (radar_objects or radar_data_transits)
+            model_version: Transit model version to request (for radar_data_transits)
             timezone: Timezone for StartTime conversion
             min_speed: Minimum speed filter
             compute_histogram: Whether to request histogram data
@@ -71,6 +73,8 @@ class RadarStatsClient:
             "units": units,
             "source": source,
         }
+        if model_version:
+            params["model_version"] = model_version
         if timezone:
             params["timezone"] = timezone
         if min_speed is not None:

--- a/internal/report/query_data/get_stats.py
+++ b/internal/report/query_data/get_stats.py
@@ -583,6 +583,10 @@ def main(date_ranges: List[Tuple[str, str]], args: argparse.Namespace):
     client = RadarStatsClient()
 
     for start_date, end_date in date_ranges:
+        model_version = None
+        if getattr(args, "source", "") == "radar_data_transits":
+            model_version = args.model_version or "rebuild-full"
+
         try:
             start_ts = parse_date_to_unix(
                 start_date, end_of_day=False, tz_name=(args.timezone or None)
@@ -615,6 +619,7 @@ def main(date_ranges: List[Tuple[str, str]], args: argparse.Namespace):
                 group=args.group,
                 units=args.units,
                 source=args.source,
+                model_version=model_version,
                 timezone=args.timezone or None,
                 min_speed=args.min_speed,
                 compute_histogram=args.histogram,
@@ -633,6 +638,7 @@ def main(date_ranges: List[Tuple[str, str]], args: argparse.Namespace):
                 group="all",
                 units=args.units,
                 source=args.source,
+                model_version=model_version,
                 timezone=args.timezone or None,
                 min_speed=args.min_speed,
                 compute_histogram=False,
@@ -651,6 +657,7 @@ def main(date_ranges: List[Tuple[str, str]], args: argparse.Namespace):
                     group="24h",
                     units=args.units,
                     source=args.source,
+                    model_version=model_version,
                     timezone=args.timezone or None,
                     min_speed=args.min_speed,
                     compute_histogram=False,
@@ -837,6 +844,11 @@ if __name__ == "__main__":
         default="radar_objects",
         choices=["radar_objects", "radar_data_transits"],
         help="Data source to query (radar_objects or radar_data_transits).",
+    )
+    parser.add_argument(
+        "--model-version",
+        default="rebuild-full",
+        help="Transit model version to query when --source=radar_data_transits. Default: rebuild-full",
     )
     parser.add_argument(
         "--timezone",

--- a/internal/report/query_data/test_api_client.py
+++ b/internal/report/query_data/test_api_client.py
@@ -59,6 +59,7 @@ class TestRadarStatsClient:
         assert metrics[0]["P50Speed"] == 25.5
         assert histogram == {}
         assert resp.status_code == 200
+        assert "model_version" not in responses.calls[0].request.url
 
     @responses.activate
     def test_get_stats_with_histogram(self):
@@ -106,6 +107,7 @@ class TestRadarStatsClient:
             group="24h",
             units="kph",
             source="radar_data_transits",
+            model_version="custom-version",
             timezone="US/Pacific",
             min_speed=5.0,
             compute_histogram=True,
@@ -121,6 +123,7 @@ class TestRadarStatsClient:
         assert "group=24h" in request.url
         assert "units=kph" in request.url
         assert "source=radar_data_transits" in request.url
+        assert "model_version=custom-version" in request.url
         assert "timezone=US%2FPacific" in request.url
         assert "min_speed=5.0" in request.url
         assert "compute_histogram=true" in request.url


### PR DESCRIPTION
## Summary
- allow RadarObjectRollupRange to accept a model version and default to rebuild-full for transit data
- expose the transit model version through the HTTP API, CLI, and Python API client
- document the new CLI usage and extend tests to assert model version handling

## Testing
- go test ./... *(fails: web/build assets missing in this environment)*
- pytest internal/report/query_data/test_api_client.py -q *(fails: missing responses dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e065ecebb48324a23aea3610771be8