### PR TITLE
[js] bump svelte-check from 4.3.3 to 4.3.4

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -47,7 +47,7 @@
 		"prettier-plugin-svelte": "^3.4.0",
 		"prettier-plugin-tailwindcss": "^0.7.1",
 		"svelte": "^5.43.6",
-		"svelte-check": "^4.3.3",
+		"svelte-check": "^4.3.4",
 		"svelte-jester": "^5.0.0",
 		"svelte-ux": "2.0.0-next.21",
 		"tailwindcss": "^4.1.17",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
         specifier: ^5.43.6
         version: 5.43.6
       svelte-check:
-        specifier: ^4.3.3
-        version: 4.3.3(picomatch@4.0.3)(svelte@5.43.6)(typescript@5.9.3)
+        specifier: ^4.3.4
+        version: 4.3.4(picomatch@4.0.3)(svelte@5.43.6)(typescript@5.9.3)
       svelte-jester:
         specifier: ^5.0.0
         version: 5.0.0(jest@30.2.0(@types/node@24.9.1))(svelte@5.43.6)
@@ -2894,8 +2894,8 @@ packages:
     resolution: {integrity: sha512-P/YLwxU5zkxtFRnL8wd34GGp8M7ns1VP2Kpf/toWKZacgs5/VlmMyYM8EEWb2CZOWxzUBcd7LK2MNPign66MZQ==}
     hasBin: true
 
-  svelte-check@4.3.3:
-    resolution: {integrity: sha512-RYP0bEwenDXzfv0P1sKAwjZSlaRyqBn0Fz1TVni58lqyEiqgwztTpmodJrGzP6ZT2aHl4MbTvWP6gbmQ3FOnBg==}
+  svelte-check@4.3.4:
+    resolution: {integrity: sha512-DVWvxhBrDsd+0hHWKfjP99lsSXASeOhHJYyuKOFYJcP7ThfSCKgjVarE8XfuMWpS5JV3AlDf+iK1YGGo2TACdw==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
     peerDependencies:
@@ -6197,7 +6197,7 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-check@4.3.3(picomatch@4.0.3)(svelte@5.43.6)(typescript@5.9.3):
+  svelte-check@4.3.4(picomatch@4.0.3)(svelte@5.43.6)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3


### PR DESCRIPTION
This pull request updates the `svelte-check` dependency to the latest patch version across the project. This ensures that the codebase benefits from the latest bug fixes and improvements provided by the updated package.

Dependency version update:

* Updated `svelte-check` from version `4.3.3` to `4.3.4` in `web/package.json` and all relevant entries in `web/pnpm-lock.yaml` to keep tooling up-to-date. [[1]](diffhunk://#diff-b861012a5dd72b8a9f3281b7cf09f5a779c98569d040b1bbc1db50f1b15e7cceL50-R50) [[2]](diffhunk://#diff-f11bfba22b3604b3a7b52e44e10f4eae265b030b5682714833ba689eda12a27bL98-R99) [[3]](diffhunk://#diff-f11bfba22b3604b3a7b52e44e10f4eae265b030b5682714833ba689eda12a27bL2897-R2898) [[4]](diffhunk://#diff-f11bfba22b3604b3a7b52e44e10f4eae265b030b5682714833ba689eda12a27bL6200-R6200)