### PR TITLE
[go][py][js] baseline all components to version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ See [Semantic Versioning 2.0.0](https://semver.org/) for detailed guidelines.
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-12-01
+
+### All Components
+
+**Version Baseline:** This release establishes version 0.2.0 as the baseline for all components (Radar, PDF Generator, Deploy Tool, Web Frontend).
+
 ## [0.1.0] - 2025-11-30
 
 ### Radar Application
@@ -127,6 +133,7 @@ See [Semantic Versioning 2.0.0](https://semver.org/) for detailed guidelines.
 
 | Release Date | Radar | PDF Generator | Deploy Tool | Web Frontend | Schema Version |
 | ------------ | ----- | ------------- | ----------- | ------------ | -------------- |
+| 2025-12-01   | 0.2.0 | 0.2.0         | 0.2.0       | 0.2.0        | 8              |
 | 2025-11-30   | 0.1.0 | 1.0.0         | 0.1.0       | 0.0.1        | 8              |
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ help:
 # =============================================================================
 # VERSION INFORMATION
 # =============================================================================
-VERSION := 0.1.0
+VERSION := 0.2.0
 GIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 LDFLAGS := -X 'main.version=$(VERSION)' -X 'main.gitSHA=$(GIT_SHA)'
 

--- a/cmd/deploy/main.go
+++ b/cmd/deploy/main.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const version = "0.1.0"
+const version = "0.2.0"
 
 var DebugMode bool
 

--- a/tools/pdf-generator/pyproject.toml
+++ b/tools/pdf-generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velocity-report-pdf-generator"
-version = "1.0.0"
+version = "0.2.0"
 description = "PDF report generator for velocity.report Go application"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "velocity.report-web",
 	"private": true,
-	"version": "0.0.1",
+	"version": "0.2.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
This pull request updates the project baseline to version 0.2.0 across all major components. The version bump is reflected in the changelog, build configuration files, and manifests for each component, ensuring consistency and clear release tracking.

Version updates across all components:

* Updated the baseline version to `0.2.0` for Radar, PDF Generator, Deploy Tool, and Web Frontend in the `CHANGELOG.md` and release table. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR48-R53) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR136)

Build and manifest file updates:

* Changed the `VERSION` variable in the `Makefile` to `0.2.0` for build consistency.
* Updated the `version` constant in `cmd/deploy/main.go` to `0.2.0`.
* Set the `version` field to `0.2.0` in `tools/pdf-generator/pyproject.toml`.
* Changed the `version` field to `0.2.0` in `web/package.json`.