### PR TITLE
[rel] bump version to 0.3.0 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,60 @@ See [Semantic Versioning 2.0.0](https://semver.org/) for detailed guidelines.
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-12-01
+
+### Radar Server
+
+#### Added
+
+- Transit worker for automatic sessionization of radar data into transits
+  - Configurable via `--enable-transit-worker` flag (enabled by default)
+  - Hourly cron-style processing with configurable interval and window
+  - Manual trigger support via API endpoint
+- Transit worker status tracking and health monitoring
+  - New `/api/transit_worker` endpoint with GET/POST support
+  - Status includes: enabled state, last run time, error info, run count, health status
+- Version and git SHA logging on server startup for better debugging
+- Database migration system with historical schema support
+  - Migration 000001: Original schema (timestamp column, pre-JSON)
+  - Migration 000002: JSON storage and write_timestamp migration
+  - Migrations now properly handle legacy databases
+
+#### Changed
+
+- Database variable naming: `db` → `database` to avoid package shadowing
+- Transit worker API responses now return full status instead of just enabled flag
+
+#### Fixed
+
+- Package shadowing issue where variable `db` conflicted with package name `db`
+- Transit worker compatibility with old database schemas via proper migrations
+
+### Deploy Tool
+
+#### Added
+
+- `--no-migrate` flag for upgrade command to skip database migrations
+- Automatic database migrations during upgrade (enabled by default)
+- Migrations run while service is stopped for safety
+
+#### Changed
+
+- Source code and Python dependency updates are now optional (skip gracefully if source not present)
+- Improved error handling for binary-only installations
+
+#### Fixed
+
+- Upgrade warnings for missing source directory (now handled gracefully)
+- Migration execution properly runs as service user with correct permissions
+
+### Documentation
+
+#### Added
+
+- Database migration documentation explaining historical schema evolution
+- SQL migration files cleaned up with better readability and comments
+
 ## [0.2.0] - 2025-12-01
 
 ### All Components

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ help:
 # =============================================================================
 # VERSION INFORMATION
 # =============================================================================
-VERSION := 0.2.0
+VERSION := 0.3.0
 GIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 LDFLAGS := -X 'main.version=$(VERSION)' -X 'main.gitSHA=$(GIT_SHA)'
 


### PR DESCRIPTION
This pull request introduces the 0.3.0 release, which brings several new features, improvements, and fixes to both the Radar Server and Deploy Tool. The most significant changes include the addition of a transit worker for automatic sessionization, a new database migration system, enhanced upgrade safety and flexibility, and improved documentation. The version number has been updated to reflect these changes.

**Radar Server Enhancements**
* Added a transit worker for automatic sessionization of radar data into transits, configurable via the `--enable-transit-worker` flag, with support for cron-style processing and manual API triggers.
* Implemented transit worker status tracking and health monitoring, exposed via a new `/api/transit_worker` endpoint with detailed status information.
* Introduced a database migration system supporting historical schema evolution and compatibility with legacy databases.

**Deploy Tool Improvements**
* Added a `--no-migrate` flag to the upgrade command, allowing users to skip database migrations, and enabled automatic migrations during upgrade for safety.
* Improved error handling for binary-only installations and made source code/Python dependency updates optional.

**General Updates**
* Updated the version number to 0.3.0 in the `Makefile`.
* Enhanced documentation, including detailed explanations of database migrations and improved SQL migration file readability.