### PR TITLE
[ci] fix changelog links in version check workflow

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -266,7 +266,7 @@ jobs:
           # Footer
           echo "---" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "📖 See [Changelog](CHANGELOG.md) for detailed guidelines." >> $GITHUB_STEP_SUMMARY
+          echo "📖 See [Changelog](../blob/main/CHANGELOG.md) for detailed guidelines." >> $GITHUB_STEP_SUMMARY
 
       - name: Comment on PR
         uses: actions/github-script@v7
@@ -384,7 +384,7 @@ jobs:
             }
 
             body += '---\n\n';
-            body += '📖 See [CHANGELOG.md](CHANGELOG.md) for detailed guidelines.\n\n';
+            body += '📖 See [CHANGELOG.md](../blob/main/CHANGELOG.md) for detailed guidelines.\n\n';
             body += '_This is an automated advisory. Review the detected changes and update versions accordingly._';
 
             if (botComment) {


### PR DESCRIPTION
This pull request updates the links to the `CHANGELOG.md` file in the `version-check.yml` GitHub Actions workflow to use a more accurate relative path. This ensures that the generated summaries and pull request comments correctly link to the changelog file in the repository.

**Workflow improvements:**

* Updated the link to `CHANGELOG.md` in the workflow summary footer to point to `../blob/main/CHANGELOG.md` for better navigation.
* Updated the link to `CHANGELOG.md` in the pull request comment body to use `../blob/main/CHANGELOG.md`, improving the accuracy of the reference.