### PR TITLE
[js] add unit tests for TRACK_COLORS in lidar types

### DIFF
--- a/web/src/lib/types/lidar.test.ts
+++ b/web/src/lib/types/lidar.test.ts
@@ -1,0 +1,40 @@
+import { TRACK_COLORS } from './lidar';
+
+describe('lidar types', () => {
+	describe('TRACK_COLORS', () => {
+		it('should have correct colour for pedestrian', () => {
+			expect(TRACK_COLORS.pedestrian).toBe('#4CAF50');
+		});
+
+		it('should have correct colour for car', () => {
+			expect(TRACK_COLORS.car).toBe('#2196F3');
+		});
+
+		it('should have correct colour for bird', () => {
+			expect(TRACK_COLORS.bird).toBe('#FFC107');
+		});
+
+		it('should have correct colour for other', () => {
+			expect(TRACK_COLORS.other).toBe('#9E9E9E');
+		});
+
+		it('should have correct colour for tentative', () => {
+			expect(TRACK_COLORS.tentative).toBe('#FF9800');
+		});
+
+		it('should have correct colour for deleted', () => {
+			expect(TRACK_COLORS.deleted).toBe('#F44336');
+		});
+
+		it('should have all 6 track colours defined', () => {
+			const keys = Object.keys(TRACK_COLORS);
+			expect(keys).toHaveLength(6);
+			expect(keys).toContain('pedestrian');
+			expect(keys).toContain('car');
+			expect(keys).toContain('bird');
+			expect(keys).toContain('other');
+			expect(keys).toContain('tentative');
+			expect(keys).toContain('deleted');
+		});
+	});
+});


### PR DESCRIPTION
This pull request adds comprehensive test coverage for several API methods and constants, focusing on error handling and correct parameter usage. It also introduces a new test suite for the `TRACK_COLORS` constant to ensure all track types have the expected color values.

**API method tests and error handling:**

* Added tests for `getTrackObservationsRange`, including cases for correct parameter usage, optional parameters, and error handling when the API returns an error. [[1]](diffhunk://#diff-53b7d2863da9166191463c178920ca55ec7d8019cbd0dff82433883f91d0a74aR21) [[2]](diffhunk://#diff-53b7d2863da9166191463c178920ca55ec7d8019cbd0dff82433883f91d0a74aR1479-R1540)
* Improved test coverage for `upsertSiteConfigPeriod`, verifying error handling for both JSON error responses and JSON parsing failures.
* Added a test for error handling in `getTimeline` when the API returns a non-OK response.

**Constant validation:**

* Introduced a new test file `lidar.test.ts` to verify that `TRACK_COLORS` contains all expected track types with the correct color codes.