### PR TITLE
[docs] lidar refactor plans

### DIFF
--- a/docs/lidar/architecture/arena-go-deprecation-and-layered-type-layout-design-20260217.md
+++ b/docs/lidar/architecture/arena-go-deprecation-and-layered-type-layout-design-20260217.md
@@ -1,0 +1,99 @@
+# `arena.go` Deprecation and Layered Type Layout Design (2026-02-17)
+
+## Objective
+
+Deprecate `internal/lidar/arena.go` and replace it with layer-aligned type files that match `docs/lidar/architecture/lidar-data-layer-model.md`.
+
+This design keeps runtime behavior unchanged while making ownership and intent of shared models much clearer.
+
+## Why this is needed
+
+`arena.go` currently mixes:
+
+- Live shared domain types used across runtime paths
+- Legacy sidecar/container types not used by runtime
+- Historical roadmap comments (including "Phase" markers) that no longer describe current code behavior
+
+This reduces readability and makes model ownership ambiguous.
+
+## Current Symbol Audit
+
+Counts below are usages in `internal/lidar` excluding `arena.go` and arena-only tests.
+
+| Symbol | Usage count | Action | Target layer |
+| --- | ---: | --- | --- |
+| `Point` | 156 | Keep | L2 Frames |
+| `FrameID` | 261 | Keep | L2 Frames |
+| `Pose` | 8 | Keep | L2 Frames / L4 transform boundary |
+| `BgSnapshot` | 35 | Keep | L3 Grid |
+| `RegionSnapshot` | 34 | Keep | L3 Grid |
+| `RegionData` | 3 | Keep | L3 Grid |
+| `WorldCluster` | 160 | Keep | L4 Perception |
+| `PoseCache` | 0 | Remove (or move only if future use is concrete) | N/A |
+| `RingBuffer` | 0 | Remove | N/A |
+| `TrackState2D` | 0 | Remove | N/A |
+| `Track` (arena variant) | 0 | Remove | N/A |
+| `TrackObs` | 0 | Remove | N/A |
+| `TrackSummary` | 0 | Remove | N/A |
+| `SidecarState` | 0 | Remove | N/A |
+| `SystemEvent` (arena variant) | 0 | Remove | N/A |
+| `RetentionConfig` | 0 | Remove | N/A |
+| `Event` + helper constructors | 0 | Remove | N/A |
+
+## Target File Layout (Same package, clear layer ownership)
+
+Keep package name `lidar` for low-risk migration, but split model files by layer.
+
+- `internal/lidar/l2_types_point.go`
+- `internal/lidar/l2_types_pose.go`
+- `internal/lidar/l3_types_background_snapshots.go`
+- `internal/lidar/l4_types_world_cluster.go`
+
+Notes:
+
+- These files contain only active shared types.
+- Removed legacy types are not relocated.
+- No import-path churn is introduced in this step.
+
+## Design Rules
+
+1. One file should map to one layer concern whenever practical.
+2. Keep type definitions byte-for-byte compatible for active persisted fields (JSON tags and field names).
+3. Do not move tracking runtime state from `tracking.go` into shared model files.
+4. No "Phase X" wording in runtime code comments; capability-based wording only.
+
+## Migration Plan
+
+1. Create the four layer-aligned type files and copy active type definitions unchanged.
+2. Compile and run LiDAR package tests to confirm no behavior drift.
+3. Delete `internal/lidar/arena.go`.
+4. Delete arena-only tests tied to removed dead types (`arena_test.go`, `arena_extended_test.go`).
+5. Add a guard check in CI/docs linting to prevent re-introducing `arena.go`-style mixed files.
+
+## Compatibility and Risk
+
+- **Runtime risk:** low, if active structs are copied exactly.
+- **Persistence risk:** low, if DB-facing field names/types remain unchanged.
+- **Testing risk:** low, but ensure removed tests only covered removed dead types.
+
+Primary regression risk is accidental field drift while copying structs. This is mitigated by exact-copy migration plus compile/tests.
+
+## Verification Checklist
+
+- `go test ./internal/lidar/...`
+- `rg -n "type (RingBuffer|SidecarState|TrackState2D|TrackObs|TrackSummary|RetentionConfig)" internal/lidar`
+  - Expected: no runtime definitions unless intentionally reintroduced
+- `rg -n "Phase [0-9]" internal/lidar`
+  - Expected: no new phase-roadmap comments in runtime code
+
+## Acceptance Criteria
+
+1. `arena.go` no longer exists.
+2. Active shared types are grouped by L2/L3/L4 aligned files.
+3. Removed symbols have no runtime references.
+4. LiDAR tests pass with unchanged behavior.
+5. Documentation references to `arena.go` are updated to new file ownership.
+
+## Follow-on (Optional, separate change)
+
+After this deprecation, a second refactor can move layer files into subpackages (`l2frames`, `l3grid`, `l4perception`) once import churn and adapter boundaries are ready.

--- a/docs/lidar/architecture/lidar-layer-alignment-refactor-review-20260217.md
+++ b/docs/lidar/architecture/lidar-layer-alignment-refactor-review-20260217.md
@@ -1,0 +1,230 @@
+# LiDAR Layer Alignment and Readability Review (2026-02-17)
+
+## Goal
+
+Make the codebase more logical and readable by aligning implementation with the six-layer model in `docs/lidar/architecture/lidar-data-layer-model.md`.
+
+This review focuses on:
+
+- Layer boundaries (L1-L6)
+- Readability and ownership clarity
+- Removing roadmap-phase comments from production code
+- Simplifying HTTP route registration/dispatch (especially `mux.HandleFunc` usage)
+
+## Baseline Evidence
+
+### Layer model exists, but orchestration bypasses boundaries
+
+- The model defines clean L1-L6 boundaries in `docs/lidar/architecture/lidar-data-layer-model.md:9`.
+- The runtime callback currently crosses many layers in one function:
+  - L3 foreground extraction in `internal/lidar/tracking_pipeline.go:156`
+  - L4 transform/clustering in `internal/lidar/tracking_pipeline.go:246` and `internal/lidar/tracking_pipeline.go:274`
+  - L5 track update in `internal/lidar/tracking_pipeline.go:311`
+  - L6 classify + persistence + publish in `internal/lidar/tracking_pipeline.go:318` and `internal/lidar/tracking_pipeline.go:384`
+- `TrackingPipelineConfig` currently pulls in DB, run manager, and visualiser concerns directly (`internal/lidar/tracking_pipeline.go:47`).
+
+### Route registration and dispatch are hard to read and evolve
+
+- `RegisterRoutes` contains 70+ explicit `mux.HandleFunc` calls (`internal/lidar/monitor/webserver.go:1190`).
+- Run-track and scene APIs manually parse path strings and method-switch internally:
+  - `internal/lidar/monitor/run_track_api.go:25`
+  - `internal/lidar/monitor/scene_api.go:45`
+
+### Hidden runtime dependencies via global registries
+
+- `FrameBuilder` registry: `internal/lidar/frame_builder.go:10`
+- `BackgroundManager` registry: `internal/lidar/background.go:1260`
+- `AnalysisRunManager` registry: `internal/lidar/analysis_run_manager.go:28`
+
+### Roadmap-phase comments have leaked into runtime code
+
+- Pipeline: `internal/lidar/tracking_pipeline.go:156`
+- Web server fields/routes: `internal/lidar/monitor/webserver.go:149` and `internal/lidar/monitor/webserver.go:1271`
+- API dispatch/placeholder text: `internal/lidar/monitor/run_track_api.go:62` and `internal/lidar/monitor/run_track_api.go:494`
+- Scene API placeholders: `internal/lidar/monitor/scene_api.go:16` and `internal/lidar/monitor/scene_api.go:364`
+- Frontend UI logic: `web/src/routes/lidar/tracks/+page.svelte:55` and `web/src/lib/components/lidar/TrackList.svelte:21`
+
+### Large files reduce local comprehensibility
+
+- `internal/lidar/monitor/webserver.go` ~3909 lines
+- `web/src/lib/components/lidar/TrackList.svelte` ~1013 lines
+- `web/src/lib/components/lidar/MapPane.svelte` ~883 lines
+- `web/src/routes/lidar/tracks/+page.svelte` ~786 lines
+
+## Target Structure Aligned to L1-L6
+
+Use layer-first package ownership inside `internal/lidar`:
+
+| Layer | Current anchors | Proposed package ownership |
+| --- | --- | --- |
+| L1 Packets | `internal/lidar/network/*`, `internal/lidar/parse/*` | `internal/lidar/l1packets/{ingest,pcap,parse}` |
+| L2 Frames | `internal/lidar/frame_builder.go`, parts of `transform.go` | `internal/lidar/l2frames/{framebuilder,geometry,export}` |
+| L3 Grid | `internal/lidar/background.go`, `internal/lidar/foreground.go` | `internal/lidar/l3grid/{background,foreground,regions}` |
+| L4 Perception | `internal/lidar/clustering.go`, `ground.go`, `voxel.go` | `internal/lidar/l4perception/{transform,cluster,ground,voxel,obs}` |
+| L5 Tracks | `internal/lidar/tracking.go`, `hungarian.go` | `internal/lidar/l5tracks/{tracker,association,lifecycle}` |
+| L6 Objects | `internal/lidar/classification.go`, `quality.go` | `internal/lidar/l6objects/{classification,quality,taxonomy}` |
+
+Cross-cutting packages:
+
+- `internal/lidar/pipeline`: orchestration only (realtime + replay use cases)
+- `internal/lidar/storage/sqlite`: DB repositories/adapters
+- `internal/lidar/adapters/{http,grpc,udp}`: transport and IO boundaries
+
+## Dependency Rules (to keep layers clean)
+
+1. `L(n)` may depend on `L(n-1)` and below, but never upward.
+2. SQL/database code is not allowed in L3-L6 domain packages.
+3. HTTP/gRPC/UDP handlers do not parse business path state manually; they delegate to use-case services.
+4. `pipeline` orchestrates layers and adapters, but does not own domain logic.
+
+## Refactor Opportunities (Concrete)
+
+### Task-specific follow-on design docs
+
+- `docs/lidar/architecture/arena-go-deprecation-and-layered-type-layout-design-20260217.md`
+  - Deprecates `internal/lidar/arena.go` and relocates active shared models by L2/L3/L4 ownership.
+- `docs/lidar/architecture/lidar-logging-stream-split-and-rubric-design-20260217.md`
+  - Splits LiDAR logging into `ops`/`debug`/`trace` streams and defines routing rubric.
+
+### 1) Split `tracking_pipeline` into explicit stage interfaces
+
+Problem:
+
+- One callback owns extraction, transform, clustering, tracking, classification, persistence, and publishing (`internal/lidar/tracking_pipeline.go:109` onward).
+
+Opportunity:
+
+- Introduce stage interfaces:
+  - `ForegroundStage` (L3)
+  - `PerceptionStage` (L4)
+  - `TrackingStage` (L5)
+  - `ObjectStage` (L6)
+  - `PersistenceSink` / `PublishSink` (adapters)
+
+Outcome:
+
+- Smaller units, clearer ownership, easier test isolation.
+
+### 2) Move persistence behind repositories/adapters
+
+Problem:
+
+- Pipeline performs SQL writes directly (`internal/lidar/tracking_pipeline.go:345`).
+- Track and scene stores are mixed into the same package as tracking math (`internal/lidar/track_store.go:1`, `internal/lidar/scene_store.go:1`, `internal/lidar/analysis_run.go:1`).
+
+Opportunity:
+
+- Keep domain structs in layer packages.
+- Move DB operations to `internal/lidar/storage/sqlite`.
+
+Outcome:
+
+- Layered domain remains readable without SQL noise.
+
+### 3) Replace large route blocks with declarative route tables
+
+Problem:
+
+- Route registration is long and duplicated (`internal/lidar/monitor/webserver.go:1190`).
+- Method guards are repeated in handlers (`internal/lidar/monitor/run_track_api.go:488`).
+
+Opportunity:
+
+- Use grouped route tables with method+pattern (Go 1.22+ `ServeMux` patterns).
+- Add wrappers: `withDB`, `method`, `featureGate`.
+
+Example direction:
+
+```go
+type route struct {
+    pattern string
+    h       http.HandlerFunc
+}
+
+var playbackRoutes = []route{
+    {"GET /api/lidar/playback/status", ws.handlePlaybackStatus},
+    {"POST /api/lidar/playback/pause", ws.handlePlaybackPause},
+    {"POST /api/lidar/playback/play", ws.handlePlaybackPlay},
+}
+```
+
+Outcome:
+
+- Faster scanning, fewer manual dispatch errors, easier endpoint diffs.
+
+### 4) Remove hidden registries from runtime control flow
+
+Problem:
+
+- Global registries hide source-of-truth wiring and make behavior context-dependent (`internal/lidar/analysis_run_manager.go:28`).
+
+Opportunity:
+
+- Build a per-sensor runtime container in `cmd/radar` and pass explicit dependencies through constructors.
+
+Outcome:
+
+- Better determinism and easier integration testing.
+
+### 5) Remove roadmap-phase comments from code and keep history in docs
+
+Problem:
+
+- Comments like "Phase X" drift over time and conflict with current behavior.
+- Some comments advertise placeholders where behavior has already changed.
+
+Opportunity:
+
+- Replace with capability-oriented comments:
+  - "Run replay endpoint"
+  - "Ground truth evaluation endpoint"
+  - "Missed region APIs"
+- Keep timeline/progress in `docs/` only.
+
+Guardrail:
+
+- Add CI grep to flag new roadmap-phase comments in runtime code:
+  - `rg -n "Phase [0-9]" internal web/src tools/visualiser-macos`
+
+### 6) Break frontend LiDAR pages into stores + focused components
+
+Problem:
+
+- Large stateful Svelte files combine fetching, playback, labeling, and rendering (`web/src/routes/lidar/tracks/+page.svelte:1`, `web/src/lib/components/lidar/TrackList.svelte:1`).
+
+Opportunity:
+
+- Extract:
+  - `tracksStore` (history, selected track, observations)
+  - `runsStore` (scene/run loading + progress)
+  - `missedRegionStore`
+- Keep components presentational where possible.
+
+Outcome:
+
+- More legible logic boundaries and easier feature iteration.
+
+## Recommended Execution Order
+
+1. **Layer contract pass (no behavior change):**
+   - Create package skeleton and interface contracts.
+   - Add dependency rules in `AGENTS.md`/contributor docs.
+2. **Pipeline extraction:**
+   - Move persistence/publish out of domain callback.
+3. **Routing simplification:**
+   - Introduce route tables + wrappers.
+   - Remove string-based path parsing where method patterns can replace it.
+4. **Registry reduction:**
+   - Move to explicit runtime wiring.
+5. **Phase-comment cleanup:**
+   - Sweep `internal/`, `web/src/`, `tools/visualiser-macos/`.
+6. **Frontend decomposition:**
+   - Split tracks page and TrackList logic.
+
+## Quick Wins (Low Risk, High Readability)
+
+- Replace phase-labeled placeholder response text in:
+  - `internal/lidar/monitor/run_track_api.go:500`
+  - `internal/lidar/monitor/scene_api.go:370`
+- Convert `RegisterRoutes` into grouped slices first (no handler logic changes) in `internal/lidar/monitor/webserver.go:1183`.
+- Add a doc-only "layer ownership matrix" to package headers as migration guidance.

--- a/docs/lidar/architecture/lidar-logging-stream-split-and-rubric-design-20260217.md
+++ b/docs/lidar/architecture/lidar-logging-stream-split-and-rubric-design-20260217.md
@@ -1,0 +1,121 @@
+# LiDAR Logging Stream Split and Rubric Design (2026-02-17)
+
+## Objective
+
+Refactor LiDAR logging from a single debug stream into multiple streams based on importance and log volume, while preserving compatibility with existing `Debugf` call sites.
+
+## Current State
+
+- LiDAR logging currently uses one optional logger in `internal/lidar/debug.go`.
+- Most instrumentation emits via `Debugf(...)`, including:
+  - actionable errors (forwarding failures, dropped packets)
+  - normal diagnostics (cluster counts, state transitions)
+  - high-volume telemetry (per-packet/per-frame stats)
+
+This makes operations hard because high-volume lines drown actionable events.
+
+## Target Logging Model
+
+Three stream model:
+
+| Stream | Purpose | Typical volume | Retention |
+| --- | --- | --- | --- |
+| `ops` | Actionable warnings/errors and significant lifecycle events | Low | Longest |
+| `debug` | Day-to-day diagnostics for troubleshooting and tuning | Medium | Medium |
+| `trace` | High-frequency packet/frame telemetry and loop-level details | High | Shortest |
+
+## Proposed API Surface
+
+Keep package-local usage simple and backward compatible:
+
+- `SetLogWriters(LogWriters{Ops, Debug, Trace io.Writer})`
+- `SetLogWriter(level LogLevel, w io.Writer)`
+- `Opsf(...)`
+- `Diagf(...)`
+- `Tracef(...)`
+- `Debugf(...)` remains available and routes via rubric/classifier
+- `SetDebugLogger(io.Writer)` remains as compatibility shim (writes all streams to one writer)
+
+## Routing Rubric (Severity + Volume)
+
+Use this rubric for each log line.
+
+1. If it indicates operator action, failure, or data-loss risk, route to `ops`.
+2. Else if it is expected at packet/frame loop frequency, route to `trace`.
+3. Else route to `debug`.
+
+### Detailed rubric matrix
+
+| Signal | Route | Rationale |
+| --- | --- | --- |
+| Error, failed operation, dropped data, timeout, repeated disconnect | `ops` | Must be visible immediately |
+| Per-packet parse messages, replay progress, queue depth every frame, FPS/bandwidth stats each cycle | `trace` | High volume; useful for deep diagnostics |
+| Cluster counts, track counts, lifecycle transitions, occasional state snapshots | `debug` | Useful context without flooding ops logs |
+
+### Keyword guidance (for classifier fallback)
+
+- `ops` keywords: `error`, `failed`, `fatal`, `panic`, `warn`, `timeout`, `dropped`
+- `trace` keywords: `packet`, `queued`, `parsed`, `progress`, `fps=`, `bandwidth`, `frame=`
+- default: `debug`
+
+Classifier is a migration helper, not a permanent substitute for explicit `Opsf/Diagf/Tracef` at hot call sites.
+
+## Example Mapping from Existing LiDAR Logs
+
+| Existing line pattern | Stream |
+| --- | --- |
+| `Error forwarding foreground packet: ...` | `ops` |
+| `[PacketForwarder] Dropped ... forwarded packets ...` | `ops` |
+| `PCAP parsed points: packet=..., points_this_packet=...` | `trace` |
+| `PCAP real-time replay progress: ...` | `trace` |
+| `[Tracking] Clustered into %d objects` | `debug` |
+| `[Tracking] %d confirmed tracks active` | `debug` |
+| `[Visualiser] Stats: fps=... bandwidth_mbps=...` (if emitted continuously) | `trace` |
+
+## Runtime Configuration Design
+
+Recommended env vars:
+
+- `VELOCITY_LIDAR_OPS_LOG`
+- `VELOCITY_LIDAR_DEBUG_LOG`
+- `VELOCITY_LIDAR_TRACE_LOG`
+
+Compatibility fallback:
+
+- If only legacy `VELOCITY_DEBUG_LOG` is set, route all streams to that file.
+
+Operational defaults:
+
+- If only one new stream path is set, route unspecified streams to the same writer to avoid silent log loss.
+
+## File/Retention Guidance
+
+- `ops`: rotate daily, retain longer (incident and reliability evidence)
+- `debug`: rotate daily or by size, moderate retention
+- `trace`: aggressive rotation and short retention (high churn)
+
+## Migration Plan
+
+1. Introduce stream-aware logging primitives and compatibility wrappers.
+2. Keep all existing `Debugf` call sites working through classifier routing.
+3. Convert known hot paths (packet/replay loops) to explicit `Tracef`.
+4. Convert clear failures/data-loss lines to explicit `Opsf`.
+5. Add tests for:
+   - stream routing
+   - classifier behavior
+   - nil writer behavior
+   - concurrent write safety
+6. Update runbook docs with env vars and retention expectations.
+
+## Acceptance Criteria
+
+1. LiDAR logging supports three streams (`ops`, `debug`, `trace`).
+2. Existing callers using `Debugf` continue to function.
+3. Actionable failures are visible in `ops` without trace noise.
+4. High-volume loops can be isolated to `trace`.
+5. Logger behavior is thread-safe under concurrent emission.
+
+## Out of Scope
+
+- Full structured logging migration (JSON fields, correlation IDs, external log pipeline integration).
+- Rewriting every historical log line in one PR; this design allows incremental migration.

--- a/docs/plans/prioritized-upcoming-work-from-docs-20260217.md
+++ b/docs/plans/prioritized-upcoming-work-from-docs-20260217.md
@@ -1,0 +1,162 @@
+# Prioritized Upcoming Work (From Full `docs/` Review) - 2026-02-17
+
+## Scope
+
+This backlog is based on:
+
+1. The architecture/readability review in `docs/lidar/architecture/lidar-layer-alignment-refactor-review-20260217.md`
+2. A review of all documentation under `docs/`
+
+## Triage Method
+
+Prioritization used four signals:
+
+1. User impact on current deployments
+2. Dependency unlocking (work that unblocks many other docs)
+3. Delivery risk if delayed
+4. Status confidence (active vs stale vs explicitly deferred)
+
+## Snapshot of Outstanding Work
+
+- Open checklist items across `docs/`: **614**
+- By area:
+  - `docs/lidar/*`: **296**
+  - `docs/plans/*`: **230**
+  - `docs/features/*`: **88**
+- Highest checklist density:
+  - `docs/plans/hint-sweep-mode.md` (57)
+  - `docs/plans/frontend-consolidation.md` (53)
+  - `docs/features/time-partitioned-data-tables.md` (49)
+  - `docs/plans/industry-standard-ml-solver-expansion-plan.md` (44)
+
+## Priority Queue
+
+### Docs-only branch tasks (current)
+
+1. `arena.go` deprecation and layered model relocation design
+   - Doc: `docs/lidar/architecture/arena-go-deprecation-and-layered-type-layout-design-20260217.md`
+   - Outcome: remove mixed/dead container file and map active shared types to L2/L3/L4 ownership.
+2. LiDAR logging stream split (`ops`/`debug`/`trace`) with routing rubric
+   - Doc: `docs/lidar/architecture/lidar-logging-stream-split-and-rubric-design-20260217.md`
+   - Outcome: isolate actionable logs from high-volume telemetry while preserving `Debugf` compatibility.
+
+## P0 (Start Now)
+
+### 1. Establish L1-L6 code boundaries and orchestration cleanup
+
+- Source: `docs/lidar/architecture/lidar-layer-alignment-refactor-review-20260217.md`
+- Why now: this is the main readability and logic issue in core runtime code; it unlocks safer future feature work.
+
+### 2. Simplify HTTP API wiring and route registration
+
+- Sources:
+  - `docs/plans/frontend-consolidation.md` (Phase 0 and Phase 5)
+  - `internal/lidar/monitor/webserver.go` route sprawl
+- Why now: route complexity is already high and directly affects maintainability and feature velocity.
+
+### 3. Close run workflow gaps in current LiDAR evaluation loop
+
+- Sources:
+  - `docs/lidar/future/track-labeling-auto-aware-tuning.md` (Phase 9)
+  - `internal/lidar/monitor/run_track_api.go` (`/reprocess` 501)
+  - `internal/lidar/monitor/scene_api.go` (`/evaluations` 501)
+- Why now: these are active user-facing gaps in an otherwise implemented labeling/evaluation flow.
+
+### 4. Documentation consistency sweep (status and checklist reconciliation)
+
+- Why now: multiple docs are marked "implemented/complete" but still show large open checklists, which distorts planning.
+- First files to reconcile:
+  - `docs/plans/hint-sweep-mode.md`
+  - `docs/lidar/visualiser/performance-investigation.md`
+  - `docs/features/speed-limit-schedules.md`
+  - `docs/lidar/future/track-labeling-auto-aware-tuning.md` (contains internal contradictions)
+
+## P1 (Next)
+
+### 5. Sweep/HINT platform hardening (Phase B/C backlog)
+
+- Source: `docs/plans/industry-standard-ml-solver-expansion-plan.md`
+- Focus:
+  - Transform pipeline
+  - Objective registry/versioning
+  - Explainability deltas and confidence penalties
+- Why next: builds on current implementation and improves trust and scalability.
+
+### 6. Settling optimization Phase 3 tooling
+
+- Source: `docs/lidar/operations/settling-time-optimization.md`
+- Focus: convergence/evaluation tool before adaptive mode.
+- Why next: direct operational value with bounded scope.
+
+### 7. Profile comparison system (Phase 9)
+
+- Source: `docs/lidar/future/track-labeling-auto-aware-tuning.md`
+- Focus: persist evaluations, expose scene evaluation APIs, add comparison UI.
+- Why next: converts single-run evaluation into repeatable decision support.
+
+### 8. Frontend consolidation Phases 1-3
+
+- Source: `docs/plans/frontend-consolidation.md`
+- Focus:
+  - Migrate status and regions pages
+  - Sweep dashboard migration to Svelte
+- Why next: reduces dual-stack UI maintenance and supports route simplification goals.
+
+## P2 (Later)
+
+### 9. Distribution/packaging plan execution
+
+- Source: `docs/plans/distribution-packaging-plan.md`
+- Why later: high value, but less urgent than runtime maintainability and current workflow gaps.
+
+### 10. Raspberry Pi image pipeline and flashing UX
+
+- Source: `docs/plans/rpi-imager-fork-design.md`
+- Why later: deployment UX improvement; depends on packaging and frontend lifecycle work.
+
+### 11. Time-partitioned raw data tables
+
+- Source: `docs/features/time-partitioned-data-tables.md`
+- Why later: major architectural/storage change with high complexity and broad blast radius.
+
+### 12. Visualiser QC program (features 1/2/3/5/7/8/10)
+
+- Sources: `docs/lidar/visualiser/06-13*.md`
+- Why later: large multi-feature program; should follow P0/P1 stabilization and doc cleanup.
+
+### 13. CLI and Python-plan closure (documentation debt)
+
+- Sources:
+  - `docs/features/cli-comprehensive-guide.md`
+  - `docs/plans/python-venv-consolidation-plan.md`
+- Why later: useful cleanup; lower urgency than LiDAR runtime architecture and active feature gaps.
+
+## P3 (Explicitly Deferred / Research)
+
+### 14. AV dataset integration and motion-capture extensions
+
+- Sources:
+  - `docs/lidar/future/av-lidar-integration-plan.md`
+  - `docs/lidar/future/motion-capture-architecture.md`
+  - `docs/lidar/future/static-pose-alignment-plan.md`
+- Why deferred: documents already label these as future/deferred AV research tracks, not core traffic-monitoring priorities.
+
+## Immediate Next Actions (2-Week Plan)
+
+1. Execute P0-4 first: reconcile doc status/checklist mismatches so planning signals are trustworthy.
+2. Start P0-1/P0-2 in parallel:
+   - Layer contracts + pipeline extraction plan
+   - Route table refactor scaffold
+3. Ship P0-3 minimal closure:
+   - Persisted scene evaluations
+   - Real `reprocess` behavior or explicit removal of the endpoint
+
+## Notes on Status Reliability
+
+During review, the following status patterns were observed and should be treated cautiously until reconciled:
+
+- Implemented/complete docs with large unchecked blocks
+- Deferred docs with "next action: begin implementation" language
+- Design docs that reference files/tables no longer present in code
+
+This is why P0 includes a doc consistency pass before broad execution.


### PR DESCRIPTION
This pull request adds several new design and planning documents to the `docs/` directory, focusing on improving the architecture, maintainability, and observability of the LiDAR subsystem. The changes introduce detailed plans for deprecating legacy code, aligning the codebase with a clear layered model, enhancing logging practices, and prioritizing upcoming work based on a comprehensive documentation review.

The most important changes are:

**LiDAR Architecture and Layer Alignment:**
- Added a comprehensive review and refactor plan to align the LiDAR codebase with a six-layer architecture (L1-L6), clarifying ownership, improving readability, and introducing dependency rules. The document also proposes concrete refactor opportunities such as splitting pipeline stages, moving persistence behind adapters, simplifying HTTP routing, and decomposing frontend logic.
- Introduced a detailed design for deprecating `internal/lidar/arena.go`, relocating active shared types into layer-aligned files, and removing dead/legacy types. The plan includes migration steps, compatibility considerations, and acceptance criteria to ensure a smooth transition.

**Logging Improvements:**
- Added a logging stream split and rubric design for LiDAR, moving from a single debug stream to three distinct streams (`ops`, `debug`, `trace`). This change aims to separate actionable events from high-volume telemetry, provides a routing rubric for log classification, and outlines a migration plan that preserves backward compatibility.

**Documentation Planning and Prioritization:**
- Created a prioritized backlog of upcoming work, derived from a full review of the documentation. The plan details immediate (P0) and next-phase (P1/P2) priorities, including architecture boundary enforcement, HTTP API simplification, workflow gap closure, and documentation consistency sweeps. It also highlights deferred research and lower-priority items.