### PR TITLE
[docs] init DESIGN.md; frontend design language doc

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -158,7 +158,7 @@ Create and reuse standard classes in shared CSS rather than repeating long utili
 
 Standards:
 
-- Shared class definitions live in web-level standards CSS (`web/src/app.css` and/or a dedicated shared stylesheet imported there).
+- Shared class definitions live in the web-level standards CSS (`web/src/routes/app.css`, which may import additional shared stylesheets as needed).
 - Extract repeated class patterns (containers, headers, control rows, stat grids, chart cards, pane shells) into named standard classes.
 - Route files should compose standard classes first, with minimal local overrides.
 - Do not copy-paste identical class bundles across multiple pages.


### PR DESCRIPTION
This pull request introduces a comprehensive design language document for frontend and visualization work across web, macOS, and chart/reporting platforms. The document establishes unified principles, style standards, and practical rules to ensure operational clarity, consistency, and maintainability across all user interfaces and visualizations.

Key highlights from the new `DESIGN.md`:

**Cross-Platform Design Language and Principles**
- Defines a strict goal of operational clarity and comparability across web UI, macOS app, and report charts, emphasizing DRY (Don't Repeat Yourself) for layout, styling, and chart semantics.
- Outlines a shared information hierarchy, semantic status colors, and a canonical color mapping for percentile charts to be used on all platforms.

**Chart and UI Alignment Rules**
- Specifies required and allowed differences for charts, including legend order, axis labeling, tick density, and handling of empty/error states, while permitting renderer-specific variations.
- Mandates alignment of chart semantics (colors, legend, axis ticks) across Svelte web, SwiftUI macOS, and matplotlib report charts.

**Web UI and Component Standards**
- Establishes a policy for using `svelte-ux` components first, with clear rules for when native elements or custom SVG/canvas are acceptable, and requires documentation for exceptions. ([DESIGN.mdR1-R213](diffhunk://#diff-3dc5dd454e080eb849ee5efaf79df2585fbe0a06804d69249b4c81da05a63875R1-R213)