### PR TITLE
[go] Add dynamic segmentation for LiDAR background regions

### DIFF
--- a/internal/lidar/background.go
+++ b/internal/lidar/background.go
@@ -154,6 +154,7 @@ type BackgroundGrid struct {
 	// Performance tracking for system_events table integration
 	LastProcessingTimeUs  int64
 	WarmupFramesRemaining int
+	WarmupInitialized     bool
 	SettlingComplete      bool
 
 	// Telemetry for monitoring (feeds into system_events)
@@ -640,6 +641,9 @@ func (bm *BackgroundManager) ResetGrid() error {
 	g.ForegroundCount = 0
 	g.BackgroundCount = 0
 	g.nonzeroCellCount = 0
+	g.WarmupFramesRemaining = 0
+	g.WarmupInitialized = false
+	g.SettlingComplete = false
 	g.RegionIndex = nil
 	g.Regions = nil
 	g.RegionsReady = false
@@ -1261,8 +1265,9 @@ func (bm *BackgroundManager) ProcessFramePolar(points []PointPolar) {
 
 	// Iterate over observed cells and update grid
 	g.mu.Lock()
-	if bm.StartTime.IsZero() {
-		bm.StartTime = now
+	if !g.WarmupInitialized && g.Params.WarmupMinFrames > 0 && !g.SettlingComplete {
+		g.WarmupFramesRemaining = g.Params.WarmupMinFrames
+		g.WarmupInitialized = true
 	}
 	if g.WarmupFramesRemaining == 0 && g.Params.WarmupMinFrames > 0 && !g.SettlingComplete {
 		g.WarmupFramesRemaining = g.Params.WarmupMinFrames

--- a/internal/lidar/monitor/webserver.go
+++ b/internal/lidar/monitor/webserver.go
@@ -34,6 +34,7 @@ import (
 	"github.com/go-echarts/go-echarts/v2/charts"
 	"github.com/go-echarts/go-echarts/v2/components"
 	"github.com/go-echarts/go-echarts/v2/opts"
+	"github.com/go-echarts/go-echarts/v2/types"
 )
 
 // ParamDef defines a configuration parameter for display and editing
@@ -1518,7 +1519,7 @@ func (ws *WebServer) handleBackgroundRegionsChart(w http.ResponseWriter, r *http
 			Title:    "LiDAR Background Regions",
 			Subtitle: fmt.Sprintf("sensor=%s regions=%d points=%d stride=%d (params in tooltip)", sensorID, len(debugData.Regions), len(debugData.Points), stride),
 		}),
-		charts.WithTooltipOpts(opts.Tooltip{Show: opts.Bool(true), Formatter: formatter}),
+		charts.WithTooltipOpts(opts.Tooltip{Show: opts.Bool(true), Formatter: types.FuncStr(formatter)}),
 		charts.WithXAxisOpts(opts.XAxis{Min: -pad, Max: pad, Name: "X (m)", NameLocation: "middle", NameGap: 25}),
 		charts.WithYAxisOpts(opts.YAxis{Min: -pad, Max: pad, Name: "Y (m)", NameLocation: "middle", NameGap: 30}),
 		charts.WithVisualMapOpts(opts.VisualMap{


### PR DESCRIPTION
## Summary

Implements dynamic region segmentation for the LiDAR background grid with warmup initialisation and a web chart endpoint.

## Changes

- **`internal/lidar/background.go`** — Add dynamic segmentation logic to BackgroundGrid, including warmup initialisation (+506 lines)
- **`internal/lidar/monitor/webserver.go`** — Add tooltip formatter and chart endpoint for background regions visualisation (+94 lines)

## Commits

- `2e4931c` Add lidar background regions
- `9a6ae75` Fix tooltip formatter in background regions chart
- `a4f3701` Add warmup initialisation to BackgroundGrid

---
*3 commits, 2 files changed, +593 −7*