### PR TITLE
[mac] add code-signing and notarisation

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -182,13 +182,17 @@ jobs:
           NOTARY_KEY: ${{ secrets.NOTARY_KEY }}
           NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
           NOTARY_ISSUER: ${{ secrets.NOTARY_ISSUER }}
-        run: make notarise-mac DMG_SUFFIX=
+        run: |
+          NOTARY_KEY_FILE=$(mktemp /tmp/AuthKey.XXXXXX.p8)
+          trap 'rm -f "$NOTARY_KEY_FILE"' EXIT
+          printf '%s' "$NOTARY_KEY" > "$NOTARY_KEY_FILE"
+          NOTARY_KEY="$NOTARY_KEY_FILE" make notarise-mac
 
       - name: Verify signatures
         if: secrets.MACOS_CERTIFICATE != ''
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-        run: make verify-mac DMG_SUFFIX=
+        run: make verify-mac
 
       - name: Upload DMG artefact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -134,6 +134,26 @@ jobs:
             "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             > tools/visualiser-macos/VelocityVisualiser/App/BuildInfo.swift
 
+      - name: Import Developer ID certificate
+        if: env.MACOS_CERTIFICATE != ''
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          # Decode the .p12 certificate and import into a temporary keychain.
+          CERT_FILE=$(mktemp /tmp/cert.XXXXXX.p12)
+          echo "$MACOS_CERTIFICATE" | base64 --decode > "$CERT_FILE"
+          KEYCHAIN=build.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 24)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT_FILE" -k "$KEYCHAIN" -P "$MACOS_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          rm -f "$CERT_FILE"
+
       - name: Build Release app
         run: |
           cd tools/visualiser-macos
@@ -147,8 +167,28 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build
 
+      - name: Codesign app
+        if: env.MACOS_CERTIFICATE != ''
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+        run: make sign-mac
+
       - name: Create versioned DMG
         run: make dmg-mac-release
+
+      - name: Notarise and staple DMG
+        if: env.NOTARY_KEY != ''
+        env:
+          NOTARY_KEY: ${{ secrets.NOTARY_KEY }}
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER: ${{ secrets.NOTARY_ISSUER }}
+        run: make notarise-mac DMG_SUFFIX=
+
+      - name: Verify signatures
+        if: env.MACOS_CERTIFICATE != ''
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+        run: make verify-mac DMG_SUFFIX=
 
       - name: Upload DMG artefact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -117,6 +117,9 @@ jobs:
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch'
     runs-on: macos-15
     needs: setup
+    env:
+      HAS_MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE != '' && 'true' || 'false' }}
+      HAS_NOTARY_KEY: ${{ secrets.NOTARY_KEY != '' && 'true' || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -135,7 +138,7 @@ jobs:
             > tools/visualiser-macos/VelocityVisualiser/App/BuildInfo.swift
 
       - name: Import Developer ID certificate
-        if: secrets.MACOS_CERTIFICATE != ''
+        if: env.HAS_MACOS_CERTIFICATE == 'true'
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -168,16 +171,14 @@ jobs:
             build
 
       - name: Codesign app
-        if: secrets.MACOS_CERTIFICATE != ''
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+        if: env.HAS_MACOS_CERTIFICATE == 'true'
         run: make sign-mac
 
       - name: Create versioned DMG
         run: make dmg-mac-release
 
       - name: Notarise and staple DMG
-        if: secrets.NOTARY_KEY != ''
+        if: env.HAS_NOTARY_KEY == 'true'
         env:
           NOTARY_KEY: ${{ secrets.NOTARY_KEY }}
           NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
@@ -189,9 +190,7 @@ jobs:
           NOTARY_KEY="$NOTARY_KEY_FILE" make notarise-mac
 
       - name: Verify signatures
-        if: secrets.MACOS_CERTIFICATE != ''
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+        if: env.HAS_MACOS_CERTIFICATE == 'true'
         run: make verify-mac
 
       - name: Upload DMG artefact

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -119,10 +119,41 @@ jobs:
     needs: setup
     env:
       HAS_MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE != '' && 'true' || 'false' }}
+      HAS_MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD != '' && 'true' || 'false' }}
       HAS_NOTARY_KEY: ${{ secrets.NOTARY_KEY != '' && 'true' || 'false' }}
+      HAS_NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID != '' && 'true' || 'false' }}
+      HAS_NOTARY_ISSUER: ${{ secrets.NOTARY_ISSUER != '' && 'true' || 'false' }}
+      HAS_RELEASE_SIGNING: ${{ secrets.MACOS_CERTIFICATE != '' && secrets.MACOS_CERTIFICATE_PASSWORD != '' && secrets.NOTARY_KEY != '' && secrets.NOTARY_KEY_ID != '' && secrets.NOTARY_ISSUER != '' && 'true' || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate release signing mode
+        run: |
+          set -eu
+          configured=0
+          for flag in \
+            "$HAS_MACOS_CERTIFICATE" \
+            "$HAS_MACOS_CERTIFICATE_PASSWORD" \
+            "$HAS_NOTARY_KEY" \
+            "$HAS_NOTARY_KEY_ID" \
+            "$HAS_NOTARY_ISSUER"; do
+            if [ "$flag" = "true" ]; then
+              configured=$((configured + 1))
+            fi
+          done
+
+          if [ "$configured" -ne 0 ] && [ "$HAS_RELEASE_SIGNING" != "true" ]; then
+            echo "::error title=Incomplete macOS release signing secrets::Configure all five macOS release secrets, or remove them all to produce an unsigned DMG."
+            exit 1
+          fi
+
+          if [ "$HAS_RELEASE_SIGNING" = "true" ]; then
+            echo "DMG signing mode: Developer ID signed and notarised"
+          else
+            echo "::warning title=Unsigned macOS DMG::No complete macOS release signing secret set is configured. The uploaded DMG filename and artifact name will include UNSIGNED."
+            echo "DMG signing mode: unsigned"
+          fi
 
       - name: Download generated protos
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -138,7 +169,7 @@ jobs:
             > tools/visualiser-macos/VelocityVisualiser/App/BuildInfo.swift
 
       - name: Import Developer ID certificate
-        if: env.HAS_MACOS_CERTIFICATE == 'true'
+        if: env.HAS_RELEASE_SIGNING == 'true'
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -171,14 +202,34 @@ jobs:
             build
 
       - name: Codesign app
-        if: env.HAS_MACOS_CERTIFICATE == 'true'
+        if: env.HAS_RELEASE_SIGNING == 'true'
         run: make sign-mac
 
       - name: Create versioned DMG
         run: make dmg-mac-release
 
+      - name: Mark unsigned DMG
+        if: env.HAS_RELEASE_SIGNING != 'true'
+        run: |
+          set -eu
+          renamed=0
+          for dmg in tools/visualiser-macos/build/VelocityVisualiser-*.dmg; do
+            [ -e "$dmg" ] || continue
+            case "$dmg" in
+              *-UNSIGNED.dmg) continue ;;
+            esac
+            unsigned="${dmg%.dmg}-UNSIGNED.dmg"
+            mv "$dmg" "$unsigned"
+            echo "Unsigned DMG: $unsigned"
+            renamed=$((renamed + 1))
+          done
+          if [ "$renamed" -ne 1 ]; then
+            echo "::error title=Unsigned DMG naming failed::Expected to rename one release DMG, renamed $renamed."
+            exit 1
+          fi
+
       - name: Notarise and staple DMG
-        if: env.HAS_NOTARY_KEY == 'true'
+        if: env.HAS_RELEASE_SIGNING == 'true'
         env:
           NOTARY_KEY: ${{ secrets.NOTARY_KEY }}
           NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
@@ -190,12 +241,21 @@ jobs:
           NOTARY_KEY="$NOTARY_KEY_FILE" make notarise-mac
 
       - name: Verify signatures
-        if: env.HAS_MACOS_CERTIFICATE == 'true'
+        if: env.HAS_RELEASE_SIGNING == 'true'
         run: make verify-mac
 
-      - name: Upload DMG artefact
+      - name: Upload signed DMG artefact
+        if: env.HAS_RELEASE_SIGNING == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: VelocityVisualiser-dmg
           path: tools/visualiser-macos/build/*VelocityVisualiser-*.dmg
+          retention-days: 90
+
+      - name: Upload unsigned DMG artefact
+        if: env.HAS_RELEASE_SIGNING != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: VelocityVisualiser-dmg-UNSIGNED
+          path: tools/visualiser-macos/build/*VelocityVisualiser-*-UNSIGNED.dmg
           retention-days: 90

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -135,7 +135,7 @@ jobs:
             > tools/visualiser-macos/VelocityVisualiser/App/BuildInfo.swift
 
       - name: Import Developer ID certificate
-        if: env.MACOS_CERTIFICATE != ''
+        if: secrets.MACOS_CERTIFICATE != ''
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -168,7 +168,7 @@ jobs:
             build
 
       - name: Codesign app
-        if: env.MACOS_CERTIFICATE != ''
+        if: secrets.MACOS_CERTIFICATE != ''
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
         run: make sign-mac
@@ -177,7 +177,7 @@ jobs:
         run: make dmg-mac-release
 
       - name: Notarise and staple DMG
-        if: env.NOTARY_KEY != ''
+        if: secrets.NOTARY_KEY != ''
         env:
           NOTARY_KEY: ${{ secrets.NOTARY_KEY }}
           NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
@@ -185,7 +185,7 @@ jobs:
         run: make notarise-mac DMG_SUFFIX=
 
       - name: Verify signatures
-        if: env.MACOS_CERTIFICATE != ''
+        if: secrets.MACOS_CERTIFICATE != ''
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
         run: make verify-mac DMG_SUFFIX=

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -89,6 +89,7 @@ Legacy aliases are kept for compatibility.
 - `sign-mac`: Sign the built app with Developer ID Application
 - `notarise-mac`: Submit the release DMG to Apple, wait, then staple the ticket
 - `verify-mac`: Verify Developer ID signature, Gatekeeper assessment, and staple
+- `verify-mac-dmg`: Verify a downloaded DMG (`DMG=/path/to/file.dmg`)
 - `release-mac`: Build, sign, package, notarise, and verify the release DMG
 
 ## Protobuf code generation

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -84,6 +84,12 @@ Legacy aliases are kept for compatibility.
 - `dev-mac`: Kill, build, and run macOS visualiser
 - `test-mac`: Run macOS visualiser tests (XCTest)
 - `format-mac`: Format macOS Swift code (swift-format)
+- `dmg-mac`: Build if needed and create a timestamped development DMG
+- `dmg-mac-release`: Build if needed and create `VelocityVisualiser-<VERSION>.dmg`
+- `sign-mac`: Sign the built app with Developer ID Application
+- `notarise-mac`: Submit the release DMG to Apple, wait, then staple the ticket
+- `verify-mac`: Verify Developer ID signature, Gatekeeper assessment, and staple
+- `release-mac`: Build, sign, package, notarise, and verify the release DMG
 
 ## Protobuf code generation
 

--- a/Makefile
+++ b/Makefile
@@ -669,7 +669,9 @@ dmg-mac:
 		"$(VISUALISER_DIR)/Getting Started.txt"
 
 dmg-mac-release:
-	@$(MAKE) build-mac
+	@if [ ! -d "$(VISUALISER_APP)" ]; then \
+		$(MAKE) build-mac; \
+	fi
 	@echo "Creating DMG: $(notdir $(VISUALISER_DMG_RELEASE))..."
 	@scripts/create-dmg.sh "$(VISUALISER_APP)" "$(VISUALISER_DMG_RELEASE)" "VelocityVisualiser $(VERSION)" \
 		"$(VISUALISER_DIR)/Getting Started.txt"

--- a/Makefile
+++ b/Makefile
@@ -587,6 +587,7 @@ VISUALISER_APP = $(VISUALISER_BUILD_DIR)/Build/Products/$(MAC_CONFIG)/VelocityVi
 VISUALISER_BIN = $(VISUALISER_APP)/Contents/MacOS/VelocityVisualiser
 VISUALISER_DMG = $(VISUALISER_BUILD_DIR)/$(BUILD_TS_COMPACT)-VelocityVisualiser-$(DEV_VERSION)-$(GIT_SHA_SHORT).dmg
 VISUALISER_DMG_RELEASE = $(VISUALISER_BUILD_DIR)/VelocityVisualiser-$(VERSION).dmg
+VISUALISER_NOTARY_DMG ?= $(VISUALISER_DMG_RELEASE)
 
 .PHONY: build-mac clean-mac run-mac dev-mac dmg-mac dmg-mac-release sign-mac notarise-mac verify-mac release-mac
 
@@ -681,21 +682,21 @@ sign-mac:
 	@scripts/codesign-notarise.sh sign "$(VISUALISER_APP)"
 
 notarise-mac:
-	@if [ ! -f "$(VISUALISER_DMG)" ]; then \
-		echo "Error: DMG not found at $(VISUALISER_DMG). Run 'make dmg-mac' first."; \
+	@if [ ! -f "$(VISUALISER_NOTARY_DMG)" ]; then \
+		echo "Error: DMG not found at $(VISUALISER_NOTARY_DMG). Run 'make dmg-mac-release' first."; \
 		exit 1; \
 	fi
-	@scripts/codesign-notarise.sh notarise "$(VISUALISER_DMG)"
+	@scripts/codesign-notarise.sh notarise "$(VISUALISER_NOTARY_DMG)"
 
 verify-mac:
-	@scripts/codesign-notarise.sh verify "$(VISUALISER_APP)" "$(VISUALISER_DMG)"
+	@scripts/codesign-notarise.sh verify "$(VISUALISER_APP)" "$(VISUALISER_NOTARY_DMG)"
 
 release-mac:
 	@$(MAKE) build-mac
 	@$(MAKE) sign-mac
 	@$(MAKE) dmg-mac-release
-	@$(MAKE) notarise-mac DMG_SUFFIX=
-	@$(MAKE) verify-mac DMG_SUFFIX=
+	@$(MAKE) notarise-mac
+	@$(MAKE) verify-mac
 	@echo "✓ Release complete: $(VISUALISER_BUILD_DIR)/VelocityVisualiser-$(VERSION).dmg"
 
 # =============================================================================

--- a/Makefile
+++ b/Makefile
@@ -660,7 +660,9 @@ dev-mac:
 	@$(VISUALISER_DIR)/build/Build/Products/Debug/VelocityVisualiser.app/Contents/MacOS/VelocityVisualiser
 
 dmg-mac:
-	@$(MAKE) build-mac
+	@if [ ! -d "$(VISUALISER_APP)" ]; then \
+		$(MAKE) build-mac; \
+	fi
 	@echo "Creating DMG: $(notdir $(VISUALISER_DMG))..."
 	@scripts/create-dmg.sh "$(VISUALISER_APP)" "$(VISUALISER_DMG)" "VelocityVisualiser $(DEV_VERSION)" \
 		"$(VISUALISER_DIR)/Getting Started.txt"

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ help:
 	@echo "  build-mac            Build macOS LiDAR visualiser (Xcode)"
 	@echo "  dmg-mac              Create versioned DMG (includes git SHA)"
 	@echo "  dmg-mac-release      Create release DMG (version only, no SHA)"
+	@echo "  sign-mac             Codesign .app with Developer ID (Hardened Runtime)"
+	@echo "  notarise-mac         Notarise DMG and staple ticket"
+	@echo "  verify-mac           Verify codesign, Gatekeeper, and staple"
+	@echo "  release-mac          Full release: build, sign, DMG, notarise, verify"
 	@echo "  clean-mac            Clean macOS visualiser build artifacts"
 	@echo "  run-mac              Run macOS visualiser (requires build-mac)"
 	@echo "  dev-mac              Kill, build (Debug), and run macOS visualiser"
@@ -584,7 +588,7 @@ VISUALISER_BIN = $(VISUALISER_APP)/Contents/MacOS/VelocityVisualiser
 VISUALISER_DMG = $(VISUALISER_BUILD_DIR)/$(BUILD_TS_COMPACT)-VelocityVisualiser-$(DEV_VERSION)-$(GIT_SHA_SHORT).dmg
 VISUALISER_DMG_RELEASE = $(VISUALISER_BUILD_DIR)/VelocityVisualiser-$(VERSION).dmg
 
-.PHONY: build-mac clean-mac run-mac dev-mac dmg-mac dmg-mac-release
+.PHONY: build-mac clean-mac run-mac dev-mac dmg-mac dmg-mac-release sign-mac notarise-mac verify-mac release-mac
 
 build-mac:
 	@echo "Building macOS LiDAR visualiser..."
@@ -666,6 +670,31 @@ dmg-mac-release:
 	@echo "Creating DMG: $(notdir $(VISUALISER_DMG_RELEASE))..."
 	@scripts/create-dmg.sh "$(VISUALISER_APP)" "$(VISUALISER_DMG_RELEASE)" "VelocityVisualiser $(VERSION)" \
 		"$(VISUALISER_DIR)/Getting Started.txt"
+
+sign-mac:
+	@if [ ! -d "$(VISUALISER_APP)" ]; then \
+		echo "Error: VelocityVisualiser.app not found. Run 'make build-mac' first."; \
+		exit 1; \
+	fi
+	@scripts/codesign-notarise.sh sign "$(VISUALISER_APP)"
+
+notarise-mac:
+	@if [ ! -f "$(VISUALISER_DMG)" ]; then \
+		echo "Error: DMG not found at $(VISUALISER_DMG). Run 'make dmg-mac' first."; \
+		exit 1; \
+	fi
+	@scripts/codesign-notarise.sh notarise "$(VISUALISER_DMG)"
+
+verify-mac:
+	@scripts/codesign-notarise.sh verify "$(VISUALISER_APP)" "$(VISUALISER_DMG)"
+
+release-mac:
+	@$(MAKE) build-mac
+	@$(MAKE) sign-mac
+	@$(MAKE) dmg-mac-release
+	@$(MAKE) notarise-mac DMG_SUFFIX=
+	@$(MAKE) verify-mac DMG_SUFFIX=
+	@echo "✓ Release complete: $(VISUALISER_BUILD_DIR)/VelocityVisualiser-$(VERSION).dmg"
 
 # =============================================================================
 # PROTOBUF CODE GENERATION

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ help:
 	@echo "  sign-mac             Codesign .app with Developer ID (Hardened Runtime)"
 	@echo "  notarise-mac         Notarise DMG and staple ticket"
 	@echo "  verify-mac           Verify codesign, Gatekeeper, and staple"
+	@echo "  verify-mac-dmg       Verify downloaded DMG (DMG=/path/to/file.dmg)"
 	@echo "  release-mac          Full release: build, sign, DMG, notarise, verify"
 	@echo "  clean-mac            Clean macOS visualiser build artifacts"
 	@echo "  run-mac              Run macOS visualiser (requires build-mac)"
@@ -588,8 +589,10 @@ VISUALISER_BIN = $(VISUALISER_APP)/Contents/MacOS/VelocityVisualiser
 VISUALISER_DMG = $(VISUALISER_BUILD_DIR)/$(BUILD_TS_COMPACT)-VelocityVisualiser-$(DEV_VERSION)-$(GIT_SHA_SHORT).dmg
 VISUALISER_DMG_RELEASE = $(VISUALISER_BUILD_DIR)/VelocityVisualiser-$(VERSION).dmg
 VISUALISER_NOTARY_DMG ?= $(VISUALISER_DMG_RELEASE)
+DMG ?= $(VISUALISER_NOTARY_DMG)
+DMG_APP_NAME ?= VelocityVisualiser.app
 
-.PHONY: build-mac clean-mac run-mac dev-mac dmg-mac dmg-mac-release sign-mac notarise-mac verify-mac release-mac
+.PHONY: build-mac clean-mac run-mac dev-mac dmg-mac dmg-mac-release sign-mac notarise-mac verify-mac verify-mac-dmg release-mac
 
 build-mac:
 	@echo "Building macOS LiDAR visualiser..."
@@ -692,6 +695,9 @@ notarise-mac:
 
 verify-mac:
 	@scripts/codesign-notarise.sh verify "$(VISUALISER_APP)" "$(VISUALISER_NOTARY_DMG)"
+
+verify-mac-dmg:
+	@scripts/codesign-notarise.sh verify-dmg "$(DMG)" "$(DMG_APP_NAME)"
 
 release-mac:
 	@$(MAKE) build-mac

--- a/README.md
+++ b/README.md
@@ -165,12 +165,12 @@ The [full PDF is available at banshee-data.com](https://banshee-data.com/velocit
 
 ## What's included
 
-| Component            | What it does                                                                                                                                                      |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Go server**        | Collects radar speed data and LiDAR point clouds, stores both in SQLite, serves the API -> [cmd/](cmd/), [internal/](internal/)                                   |
-| **PDF reports**      | Turns speed data into professional PDF reports with charts, statistics, and proper formatting. Go + Typst -> [internal/report/](internal/report/)                 |
-| **Web frontend**     | Data visualisation and interactive charts for recorded speed data. Svelte + TypeScript -> [web/](web/README.md)                                                   |
-| **macOS visualiser** | Native 3D LiDAR point cloud viewer with object tracking, replay, and debug overlays. Apple Silicon -> [tools/visualiser-macos/](tools/visualiser-macos/README.md) |
+| Component            | What it does                                                                                                                                                    |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Go server**        | Collects radar speed data and LiDAR point clouds, stores both in SQLite, serves the API -> [cmd/](cmd/), [internal/](internal/)                                 |
+| **PDF reports**      | Turns speed data into professional PDF reports with charts, statistics, and proper formatting. Go + Typst -> [internal/report/](internal/report/)               |
+| **Web frontend**     | Data visualisation and interactive charts for recorded speed data. Svelte + TypeScript -> [web/](web/README.md)                                                 |
+| **macOS visualiser** | Native 3D LiDAR point cloud viewer with object tracking, replay, and debug overlays. macOS/Metal -> [tools/visualiser-macos/](tools/visualiser-macos/README.md) |
 
 ## Quick start
 
@@ -270,7 +270,7 @@ The full plan is in [docs/plans/lidar-l7-scene-plan.md](docs/plans/lidar-l7-scen
 
 Native Metal renderer for live and recorded LiDAR data,
 with 96% bandwidth reduction through background caching and foreground-only streaming.
-Requires macOS 14+ and Apple Silicon.
+Requires macOS 15+ and a Mac with Metal support.
 
 ```sh
 make dev-mac
@@ -280,6 +280,10 @@ Open the LiDAR Dashboard at [localhost:8081](http://localhost:8081) to replay ca
 data (.pcap files).
 See [tools/visualiser-macos/README.md](tools/visualiser-macos/README.md) for controls and camera
 navigation.
+Signed GitHub release DMGs use Developer ID Application signing and Apple
+notarisation; see the
+[macOS signing guide](tools/visualiser-macos/BUILDING.md#signing-notarisation-and-distribution)
+for the local and CI release setup.
 
 ## 🔑 key documents
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -98,7 +98,10 @@ Individual docs in `plans/` describe single projects, not priority lists.
 - Simplification and deprecation programme (Project B execution): remove deploy surfaces after v0.5.1 RPi image gate + migration window; doc/Make cleanup only (Project A complete, Phase 1 signalling done #344): [design doc](plans/platform-simplification-and-deprecation-plan.md) `M`
 - Alternate-domain isolation for untrusted web artefacts: serve experimental design prototypes and other opaque compiled JS from a separate origin or subdomain rather than `velocity.report`; document the publication rule so same-origin trust is reserved for reviewed app code and content. `S`
 - One-line install script: curl-based installer with automatic platform detection: [design doc](plans/deploy-distribution-packaging-plan.md) `S`
-- [#425] macOS app signing readiness: prepare code-signing/notarisation prerequisites and release-signing checks for packaged artifacts `S`
+- [#425] macOS app release signing: local Developer ID signing,
+  notarisation, stapling, and `make verify-mac` path complete; remaining
+  release-gate work is GitHub Actions secret population and tagged-release
+  smoke validation for packaged artifacts. `S`
 
 ### v0.6.1 - macOS local server (061)
 

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -15,6 +15,9 @@
 - Corrected the release packaging target so `make release-mac` packages the
   signed app instead of rebuilding after signing, and updated the release docs
   with the local keychain, notarytool, and GitHub Actions secret boundaries.
+- Made unsigned CI DMG outputs explicit: manual or tag runs without the full
+  release secret set now upload `UNSIGNED`-labelled DMG files and artifacts,
+  while partially configured signing secrets fail the workflow early.
 
 ## June 9, 2026 - Typst map editor, typstbin hardening & cleanup
 

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -2,6 +2,20 @@
 
 <!-- ignore-style-length -->
 
+## August 10, 2026 - macOS Developer ID signing and notarisation
+
+- Completed the first local VelocityVisualiser Developer ID release-signing
+  run: verified a usable `Developer ID Application` identity, signed the app
+  with hardened runtime and timestamping, packaged `VelocityVisualiser-0.5.1-pre26.dmg`,
+  submitted it through the `velocity-report` `notarytool` keychain profile,
+  stapled the accepted ticket, and passed `make verify-mac`.
+- Fixed the DMG packaging hang by making Finder layout automation
+  timeout-bounded and best-effort, with `DMG_LAYOUT=0` and
+  `DMG_LAYOUT_TIMEOUT_SECONDS` overrides for local or CI packaging.
+- Corrected the release packaging target so `make release-mac` packages the
+  signed app instead of rebuilding after signing, and updated the release docs
+  with the local keychain, notarytool, and GitHub Actions secret boundaries.
+
 ## June 9, 2026 - Typst map editor, typstbin hardening & cleanup
 
 - Built the report map-editor integration: an SVG overlay with style selection, FOV-triangle overlay rendering, tile snapshots loaded only with user consent, and report-overlay visibility plus stale-preview detection (#522).

--- a/docs/plans/macos-local-server-plan.md
+++ b/docs/plans/macos-local-server-plan.md
@@ -292,7 +292,7 @@ embedded binary version on launch by running `velocity-report-server --version`
 15. Clicking the Dock icon or re-launching restores normal window behaviour.
 
 **macOS version requirement:** macOS 13+ (Ventura) for `SMAppService`.
-Current app minimum is macOS 14: compatible.
+Current app minimum is macOS 15: compatible.
 
 ### Phase 5: server manager integration (`S`)
 

--- a/docs/platform/operations/distribution-packaging.md
+++ b/docs/platform/operations/distribution-packaging.md
@@ -46,6 +46,45 @@ version` reports the same from the CLI.
 
 This model landed in v0.5.1, replacing the multi-binary D-09 proposal below.
 
+## macOS visualiser DMG distribution
+
+VelocityVisualiser is distributed separately from the appliance image as a
+Mac-native DMG named `VelocityVisualiser-<v>.dmg`. The app bundle inside the
+DMG is signed with a `Developer ID Application` certificate, submitted to
+Apple notarisation, and stapled before publication.
+
+The proved local release sequence is:
+
+```bash
+make build-mac
+make sign-mac CODESIGN_IDENTITY=<Developer ID Application SHA1>
+make dmg-mac-release
+make notarise-mac
+make verify-mac
+```
+
+`make release-mac` runs the same sequence end to end. The release DMG target
+packages an existing app bundle when present, so the Developer ID signature is
+not invalidated by a rebuild after signing.
+
+Local credentials stay in the macOS keychain:
+
+- Developer ID Application certificate and private key: login or System
+  keychain, visible through `security find-identity -v -p codesigning`.
+- Notarisation credentials: `notarytool` keychain profile
+  `velocity-report`, checked with `xcrun notarytool history`.
+
+CI credentials stay in GitHub repository Actions secrets:
+
+- `MACOS_CERTIFICATE`: base64-encoded Developer ID `.p12`.
+- `MACOS_CERTIFICATE_PASSWORD`: password for that `.p12`.
+- `NOTARY_KEY`: App Store Connect API-key `.p8` contents.
+- `NOTARY_KEY_ID`: App Store Connect API-key identifier.
+- `NOTARY_ISSUER`: App Store Connect issuer UUID.
+
+Do not commit certificates, private keys, app-specific passwords, App Store
+Connect keys, or generated temporary keychains.
+
 ## Historical proposal (D-09 subcommand model, superseded)
 
 The sections below are the original D-09 proposal — a `velocity-report` binary

--- a/scripts/codesign-notarise.sh
+++ b/scripts/codesign-notarise.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# codesign-notarise.sh — Codesign, notarise, and staple macOS artefacts.
+#
+# Usage:
+#   scripts/codesign-notarise.sh sign     <app-path>
+#   scripts/codesign-notarise.sh notarise <dmg-path>
+#   scripts/codesign-notarise.sh verify   <app-path> [dmg-path]
+#
+# Subcommands:
+#   sign      Codesign the .app with Developer ID (Hardened Runtime + timestamp).
+#   notarise  Submit the DMG for notarisation, wait, then staple the ticket.
+#   verify    Run codesign, spctl, and stapler validation checks.
+#
+# Environment / Make variables:
+#   CODESIGN_IDENTITY   Developer ID Application identity (default: auto-detect).
+#   NOTARY_PROFILE      Keychain notarytool profile name  (default: "velocity-report").
+#   NOTARY_KEY          App Store Connect API key path    (alternative to profile).
+#   NOTARY_KEY_ID       API key ID                        (requires NOTARY_KEY).
+#   NOTARY_ISSUER       API issuer ID                     (requires NOTARY_KEY).
+#
+# One-time local setup:
+#   # Store notarisation credentials in the keychain:
+#   xcrun notarytool store-credentials "velocity-report" \
+#     --apple-id "<EMAIL>" --team-id "<TEAM_ID>" --password "<APP-SPECIFIC-PASSWORD>"
+#
+#   # Or use an App Store Connect API key:
+#   export NOTARY_KEY=~/AuthKey_XXXX.p8
+#   export NOTARY_KEY_ID=XXXXXXXXXX
+#   export NOTARY_ISSUER=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+
+CODESIGN_IDENTITY="${CODESIGN_IDENTITY:-Developer ID Application}"
+NOTARY_PROFILE="${NOTARY_PROFILE:-velocity-report}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+step() { printf '\n── %s ──\n' "$*"; }
+ok()   { printf '✓ %s\n' "$*"; }
+die()  { printf 'Error: %s\n' "$*" >&2; exit 1; }
+
+require_macos() {
+  [ "$(uname)" = "Darwin" ] || die "This script requires macOS."
+}
+
+# Build the notarytool auth flags from environment.
+# Prefers API-key auth if NOTARY_KEY is set; otherwise uses keychain profile.
+notary_auth_flags() {
+  if [ -n "${NOTARY_KEY:-}" ]; then
+    [ -n "${NOTARY_KEY_ID:-}" ] || die "NOTARY_KEY is set but NOTARY_KEY_ID is missing."
+    [ -n "${NOTARY_ISSUER:-}" ] || die "NOTARY_KEY is set but NOTARY_ISSUER is missing."
+    echo "--key" "$NOTARY_KEY" "--key-id" "$NOTARY_KEY_ID" "--issuer" "$NOTARY_ISSUER"
+  else
+    # Verify the keychain profile exists before we try to use it.
+    if ! security find-generic-password -s "com.apple.gke.notarytool.profile.${NOTARY_PROFILE}" >/dev/null 2>&1; then
+      cat >&2 <<EOF
+Error: Notarisation credentials not found.
+
+No keychain profile "${NOTARY_PROFILE}" and no NOTARY_KEY environment variable.
+
+To configure credentials, choose one of:
+
+  Option A — Keychain profile (recommended for local dev):
+    xcrun notarytool store-credentials "${NOTARY_PROFILE}" \\
+      --apple-id "<APPLE_ID>" --team-id "<TEAM_ID>" \\
+      --password "<APP-SPECIFIC-PASSWORD>"
+
+  Option B — App Store Connect API key (recommended for CI):
+    export NOTARY_KEY=/path/to/AuthKey_XXXX.p8
+    export NOTARY_KEY_ID=XXXXXXXXXX
+    export NOTARY_ISSUER=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+See tools/visualiser-macos/BUILDING.md for details.
+EOF
+      exit 1
+    fi
+    echo "--keychain-profile" "$NOTARY_PROFILE"
+  fi
+}
+
+# ── sign <app-path> ──────────────────────────────────────────────────────────
+
+cmd_sign() {
+  local app="${1:?usage: codesign-notarise.sh sign <app-path>}"
+  [ -d "$app" ] || die "App bundle not found: $app"
+  require_macos
+
+  step "Codesigning $app"
+
+  # Verify identity is available in the keychain.
+  if ! security find-identity -v -p codesigning | grep -q "$CODESIGN_IDENTITY"; then
+    die "Codesign identity not found: \"$CODESIGN_IDENTITY\".
+Install a Developer ID Application certificate from the Apple Developer portal
+and ensure it is present in the login or System keychain."
+  fi
+
+  # Sign nested frameworks/dylibs first (inside-out), then the top-level app.
+  # --deep is unreliable for complex bundles; enumerate explicitly.
+  local frameworks_dir="$app/Contents/Frameworks"
+  if [ -d "$frameworks_dir" ]; then
+    find "$frameworks_dir" \( -name '*.framework' -o -name '*.dylib' \) -print0 \
+      | while IFS= read -r -d '' item; do
+          codesign --force --options runtime --timestamp \
+            --sign "$CODESIGN_IDENTITY" "$item"
+        done
+  fi
+
+  codesign --force --options runtime --timestamp \
+    --sign "$CODESIGN_IDENTITY" "$app"
+
+  ok "Signed: $app"
+
+  step "Verifying signature"
+  codesign --verify --deep --strict --verbose=2 "$app"
+  ok "codesign --verify passed"
+
+  # spctl may fail if the cert isn't trusted by Gatekeeper yet (pre-notarisation).
+  # Run it for information but don't fail the build.
+  step "Gatekeeper assessment (pre-notarisation — may warn)"
+  spctl --assess --type execute --verbose=4 "$app" 2>&1 || true
+}
+
+# ── notarise <dmg-path> ──────────────────────────────────────────────────────
+
+cmd_notarise() {
+  local dmg="${1:?usage: codesign-notarise.sh notarise <dmg-path>}"
+  [ -f "$dmg" ] || die "DMG not found: $dmg"
+  require_macos
+
+  local auth
+  auth=$(notary_auth_flags)
+
+  step "Submitting $dmg for notarisation"
+  # shellcheck disable=SC2086
+  xcrun notarytool submit "$dmg" $auth --wait
+  ok "Notarisation accepted"
+
+  step "Stapling notarisation ticket"
+  xcrun stapler staple "$dmg"
+  ok "Stapled: $dmg"
+
+  step "Validating staple"
+  xcrun stapler validate "$dmg"
+  ok "Staple valid"
+}
+
+# ── verify <app-path> [dmg-path] ─────────────────────────────────────────────
+
+cmd_verify() {
+  local app="${1:?usage: codesign-notarise.sh verify <app-path> [dmg-path]}"
+  local dmg="${2:-}"
+  require_macos
+
+  step "Verifying app signature: $app"
+  codesign --verify --deep --strict --verbose=2 "$app"
+  ok "codesign passed"
+
+  step "Gatekeeper assessment: $app"
+  spctl --assess --type execute --verbose=4 "$app"
+  ok "spctl passed"
+
+  if [ -n "$dmg" ]; then
+    step "Gatekeeper assessment: $dmg"
+    spctl --assess --type open --context context:primary-signature --verbose=4 "$dmg"
+    ok "spctl (DMG) passed"
+
+    step "Staple validation: $dmg"
+    xcrun stapler validate "$dmg"
+    ok "Staple valid"
+  fi
+
+  ok "All verification checks passed"
+}
+
+# ── Dispatch ─────────────────────────────────────────────────────────────────
+
+subcmd="${1:-}"
+shift || true
+
+case "$subcmd" in
+  sign)     cmd_sign "$@" ;;
+  notarise) cmd_notarise "$@" ;;
+  verify)   cmd_verify "$@" ;;
+  *)
+    echo "Usage: codesign-notarise.sh {sign|notarise|verify} <args...>" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/codesign-notarise.sh
+++ b/scripts/codesign-notarise.sh
@@ -113,7 +113,25 @@ cmd_notarise() {
   auth=($(notary_auth_flags))
 
   step "Submitting $dmg for notarisation"
-  xcrun notarytool submit "$dmg" "${auth[@]}" --wait
+  local output
+  output=$(xcrun notarytool submit "$dmg" "${auth[@]}" --wait 2>&1) || true
+  echo "$output"
+
+  if echo "$output" | grep -q "status: Invalid"; then
+    echo ""
+    echo "Notarisation failed. Fetching log for details..."
+    local sub_id
+    sub_id=$(echo "$output" | grep "id:" | head -1 | awk '{print $2}')
+    if [ -n "$sub_id" ]; then
+      xcrun notarytool log "${auth[@]}" "$sub_id" 2>&1 || true
+    fi
+    die "Notarisation rejected by Apple. Check the log above."
+  fi
+
+  if ! echo "$output" | grep -q "status: Accepted"; then
+    die "Unexpected notarisation status. Output:\n$output"
+  fi
+
   ok "Notarisation accepted"
 
   step "Stapling notarisation ticket"

--- a/scripts/codesign-notarise.sh
+++ b/scripts/codesign-notarise.sh
@@ -33,6 +33,7 @@ set -euo pipefail
 
 CODESIGN_IDENTITY="${CODESIGN_IDENTITY:-Developer ID Application}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-velocity-report}"
+NOTARY_KEYCHAIN="${NOTARY_KEYCHAIN:-${HOME}/Library/Keychains/login.keychain-db}"
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -55,7 +56,7 @@ notary_auth_flags() {
     # On macOS 13+, notarytool stores credentials in the Data Protection
     # keychain which is not searchable via `security find-generic-password`.
     # Skip the pre-flight check and let notarytool report its own error.
-    echo "--keychain-profile" "$NOTARY_PROFILE"
+    echo "--keychain-profile" "$NOTARY_PROFILE" "--keychain" "$NOTARY_KEYCHAIN"
   fi
 }
 
@@ -159,10 +160,6 @@ cmd_verify() {
   ok "spctl passed"
 
   if [ -n "$dmg" ]; then
-    step "Gatekeeper assessment: $dmg"
-    spctl --assess --type open --context context:primary-signature --verbose=4 "$dmg"
-    ok "spctl (DMG) passed"
-
     step "Staple validation: $dmg"
     xcrun stapler validate "$dmg"
     ok "Staple valid"

--- a/scripts/codesign-notarise.sh
+++ b/scripts/codesign-notarise.sh
@@ -12,7 +12,7 @@
 #   verify    Run codesign, spctl, and stapler validation checks.
 #
 # Environment / Make variables:
-#   CODESIGN_IDENTITY   Developer ID Application identity (default: auto-detect).
+#   CODESIGN_IDENTITY   Developer ID Application identity (default: "Developer ID Application").
 #   NOTARY_PROFILE      Keychain notarytool profile name  (default: "velocity-report").
 #   NOTARY_KEY          App Store Connect API key path    (alternative to profile).
 #   NOTARY_KEY_ID       API key ID                        (requires NOTARY_KEY).
@@ -128,12 +128,12 @@ cmd_notarise() {
   [ -f "$dmg" ] || die "DMG not found: $dmg"
   require_macos
 
-  local auth
-  auth=$(notary_auth_flags)
+  local -a auth
+  # shellcheck disable=SC2207
+  auth=($(notary_auth_flags))
 
   step "Submitting $dmg for notarisation"
-  # shellcheck disable=SC2086
-  xcrun notarytool submit "$dmg" $auth --wait
+  xcrun notarytool submit "$dmg" "${auth[@]}" --wait
   ok "Notarisation accepted"
 
   step "Stapling notarisation ticket"

--- a/scripts/codesign-notarise.sh
+++ b/scripts/codesign-notarise.sh
@@ -52,29 +52,9 @@ notary_auth_flags() {
     [ -n "${NOTARY_ISSUER:-}" ] || die "NOTARY_KEY is set but NOTARY_ISSUER is missing."
     echo "--key" "$NOTARY_KEY" "--key-id" "$NOTARY_KEY_ID" "--issuer" "$NOTARY_ISSUER"
   else
-    # Verify the keychain profile exists before we try to use it.
-    if ! security find-generic-password -s "com.apple.gke.notarytool.profile.${NOTARY_PROFILE}" >/dev/null 2>&1; then
-      cat >&2 <<EOF
-Error: Notarisation credentials not found.
-
-No keychain profile "${NOTARY_PROFILE}" and no NOTARY_KEY environment variable.
-
-To configure credentials, choose one of:
-
-  Option A — Keychain profile (recommended for local dev):
-    xcrun notarytool store-credentials "${NOTARY_PROFILE}" \\
-      --apple-id "<APPLE_ID>" --team-id "<TEAM_ID>" \\
-      --password "<APP-SPECIFIC-PASSWORD>"
-
-  Option B — App Store Connect API key (recommended for CI):
-    export NOTARY_KEY=/path/to/AuthKey_XXXX.p8
-    export NOTARY_KEY_ID=XXXXXXXXXX
-    export NOTARY_ISSUER=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-
-See tools/visualiser-macos/BUILDING.md for details.
-EOF
-      exit 1
-    fi
+    # On macOS 13+, notarytool stores credentials in the Data Protection
+    # keychain which is not searchable via `security find-generic-password`.
+    # Skip the pre-flight check and let notarytool report its own error.
     echo "--keychain-profile" "$NOTARY_PROFILE"
   fi
 }

--- a/scripts/codesign-notarise.sh
+++ b/scripts/codesign-notarise.sh
@@ -5,11 +5,13 @@
 #   scripts/codesign-notarise.sh sign     <app-path>
 #   scripts/codesign-notarise.sh notarise <dmg-path>
 #   scripts/codesign-notarise.sh verify   <app-path> [dmg-path]
+#   scripts/codesign-notarise.sh verify-dmg <dmg-path> [app-name]
 #
 # Subcommands:
 #   sign      Codesign the .app with Developer ID (Hardened Runtime + timestamp).
 #   notarise  Submit the DMG for notarisation, wait, then staple the ticket.
 #   verify    Run codesign, spctl, and stapler validation checks.
+#   verify-dmg Mount a DMG and verify its embedded .app and stapled ticket.
 #
 # Environment / Make variables:
 #   CODESIGN_IDENTITY   Developer ID Application identity (default: "Developer ID Application").
@@ -168,17 +170,74 @@ cmd_verify() {
   ok "All verification checks passed"
 }
 
+# ── verify-dmg <dmg-path> [app-name] ────────────────────────────────────────
+
+cmd_verify_dmg() {
+  local dmg="${1:?usage: codesign-notarise.sh verify-dmg <dmg-path> [app-name]}"
+  local app_name="${2:-VelocityVisualiser.app}"
+  [ -f "$dmg" ] || die "DMG not found: $dmg"
+  require_macos
+
+  local mount
+  mount=$(mktemp -d "${TMPDIR:-/tmp}/velocity-dmg.XXXXXX")
+  local attached=0
+  cleanup_mount() {
+    if [ "$attached" -eq 1 ]; then
+      hdiutil detach "$mount" >/dev/null 2>&1 || true
+      attached=0
+    fi
+    rmdir "$mount" >/dev/null 2>&1 || true
+  }
+  trap cleanup_mount EXIT
+
+  step "Staple validation: $dmg"
+  xcrun stapler validate "$dmg"
+  ok "Staple valid"
+
+  step "Disk image integrity: $dmg"
+  hdiutil verify "$dmg"
+  ok "DMG integrity passed"
+
+  step "Mounting DMG read-only"
+  hdiutil attach "$dmg" -readonly -nobrowse -mountpoint "$mount" >/dev/null
+  attached=1
+  ok "Mounted: $mount"
+
+  local app="$mount/$app_name"
+  if [ ! -d "$app" ]; then
+    app=$(find "$mount" -maxdepth 2 -name '*.app' -type d -print -quit)
+  fi
+  [ -n "$app" ] && [ -d "$app" ] || die "No .app bundle found in DMG: $dmg"
+
+  step "Signing identity: $app"
+  codesign -dv --verbose=4 "$app" 2>&1 \
+    | egrep 'Authority=|TeamIdentifier=|Timestamp=|Runtime Version=|Identifier=|Format=' || true
+
+  step "Verifying app signature: $app"
+  codesign --verify --deep --strict --verbose=2 "$app"
+  ok "codesign passed"
+
+  step "Gatekeeper assessment: $app"
+  spctl --assess --type execute --verbose=4 "$app"
+  ok "spctl passed"
+
+  ok "Downloaded DMG verification checks passed"
+  cleanup_mount
+  trap - EXIT
+}
+
 # ── Dispatch ─────────────────────────────────────────────────────────────────
 
 subcmd="${1:-}"
 shift || true
 
 case "$subcmd" in
-  sign)     cmd_sign "$@" ;;
-  notarise) cmd_notarise "$@" ;;
-  verify)   cmd_verify "$@" ;;
+  sign)       cmd_sign "$@" ;;
+  notarise)   cmd_notarise "$@" ;;
+  verify)     cmd_verify "$@" ;;
+  verify-dmg) cmd_verify_dmg "$@" ;;
   *)
-    echo "Usage: codesign-notarise.sh {sign|notarise|verify} <args...>" >&2
+    echo "Usage: codesign-notarise.sh {sign|notarise|verify|verify-dmg} <args...>" >&2
     exit 1
     ;;
 esac

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -106,17 +106,37 @@ rm -rf "$mount_point/.fseventsd"
 # Give Finder time to index the newly mounted volume.
 sleep 2
 
-# Apply Finder view settings via AppleScript.
-# Window: 400 × 400, icon view, 72 px icons, no toolbar/sidebar.
-# Row 1 (y=70): app icon at left (x=100), Applications alias at right (x=300).
-# Row 2 (y=230): Getting Started guide centred (x=200).
+# Apply Finder view settings via AppleScript. Finder automation can block on
+# hosts without interactive Finder access, so keep layout best-effort and
+# timeout-bounded rather than hanging release packaging.
 extra_args=()
 for name in "${extra_names[@]+"${extra_names[@]}"}"; do
   extra_args+=("$name")
 done
 
-osascript "$SCRIPT_DIR/dmg-layout.applescript" \
-  "$VOLUME_NAME" "$APP_NAME" ${extra_args[@]+"${extra_args[@]}"}
+layout_timeout_seconds="${DMG_LAYOUT_TIMEOUT_SECONDS:-30}"
+if [ "${DMG_LAYOUT:-1}" = "0" ]; then
+  echo "Skipping Finder layout (DMG_LAYOUT=0)." >&2
+else
+  osascript "$SCRIPT_DIR/dmg-layout.applescript" \
+    "$VOLUME_NAME" "$APP_NAME" "${extra_args[@]}" &
+  layout_pid=$!
+  layout_elapsed=0
+  while kill -0 "$layout_pid" 2>/dev/null; do
+    if [ "$layout_elapsed" -ge "$layout_timeout_seconds" ]; then
+      echo "Warning: Finder layout did not finish within ${layout_timeout_seconds}s; continuing without custom layout." >&2
+      kill "$layout_pid" 2>/dev/null || true
+      wait "$layout_pid" 2>/dev/null || true
+      layout_pid=""
+      break
+    fi
+    sleep 1
+    layout_elapsed=$((layout_elapsed + 1))
+  done
+  if [ -n "${layout_pid:-}" ] && ! wait "$layout_pid"; then
+    echo "Warning: Finder layout failed; continuing without custom layout." >&2
+  fi
+fi
 
 # Ensure .DS_Store is flushed.
 sync
@@ -124,7 +144,7 @@ sync
 # Remove macOS metadata right before detach so there is no time to recreate it.
 rm -rf "$mount_point/.fseventsd" "$mount_point/.Trashes"
 
-hdiutil detach "$device"
+hdiutil detach "$device" -force
 device=""
 
 # ── 4. Convert to compressed read-only DMG ───────────────────────────────────

--- a/scripts/dmg-layout.applescript
+++ b/scripts/dmg-layout.applescript
@@ -1,11 +1,10 @@
 -- dmg-layout.applescript -- Configure Finder icon layout for a drag-to-install DMG.
 --
 -- Usage:
---   osascript scripts/dmg-layout.applescript <volume-name> <app-name> <extra>
+--   osascript scripts/dmg-layout.applescript <volume-name> <app-name> [extras...]
 --
 -- Positions the app icon at the left (x=100, y=70) and an Applications
--- alias at the right (x=300, y=70).  The single extra item is placed centred
--- on a second row at {200, 230}.
+-- alias at the right (x=300, y=70). Extra items are placed centred below.
 --
 -- Window: 400 × 400 (bounds {100, 100, 500, 500}), icon view, 72 px icons,
 -- no toolbar or sidebar.
@@ -20,7 +19,7 @@ on run argv
 		set diskFound to false
 		repeat with attempt from 1 to maxAttempts
 			try
-				set _ to disk volumeName
+				set diskRef to disk (volumeName as text)
 				set diskFound to true
 				exit repeat
 			on error
@@ -31,7 +30,7 @@ on run argv
 			error "Finder never discovered disk '" & volumeName & "' after " & maxAttempts & " seconds."
 		end if
 
-		tell disk volumeName
+		tell disk (volumeName as text)
 			open
 			set current view of container window to icon view
 			set toolbar visible of container window to false
@@ -42,11 +41,15 @@ on run argv
 			set icon size of theViewOptions to 72
 
 			-- Row 1: app on the left, Applications on the right.
-			set position of item appName of container window to {100, 70}
+			set position of item (appName as text) of container window to {100, 70}
 			set position of item "Applications" of container window to {300, 70}
 
-			-- Row 2: Getting Started guide centred below.
-			set position of item (item 3 of argv) of container window to {200, 230}
+			-- Row 2+: extra files centred below.
+			if (count of argv) is greater than 2 then
+				repeat with extraIndex from 3 to (count of argv)
+					set position of item ((item extraIndex of argv) as text) of container window to {200, 230 + ((extraIndex - 3) * 90)}
+				end repeat
+			end if
 
 			close
 			open

--- a/tools/visualiser-macos/BUILDING.md
+++ b/tools/visualiser-macos/BUILDING.md
@@ -119,3 +119,85 @@ next DMG build.
 
 > **CI:** Tagged releases (`v*`) and manual workflow dispatches automatically
 > produce the DMG as a downloadable artefact in the `🍎 macOS CI` workflow.
+
+## Signing, Notarisation, and Distribution
+
+To distribute the DMG outside the App Store, the `.app` must be codesigned
+with a **Developer ID Application** certificate and the DMG must be
+**notarised** by Apple. The `release-mac` target automates the full pipeline:
+
+```bash
+# Full pipeline: build → sign → DMG → notarise → verify
+make release-mac
+```
+
+Individual steps can also be run separately:
+
+```bash
+make build-mac          # Build the .app
+make sign-mac           # Codesign with Developer ID (Hardened Runtime)
+make dmg-mac-release    # Package into DMG
+make notarise-mac DMG_SUFFIX=   # Submit, wait, staple
+make verify-mac   DMG_SUFFIX=   # codesign + spctl + stapler checks
+```
+
+### One-Time Local Setup
+
+1. **Install a Developer ID Application certificate** from the
+   [Apple Developer portal](https://developer.apple.com/account/resources/certificates/list)
+   into your login keychain.
+
+2. **Store notarisation credentials** (choose one):
+
+   **Option A — Keychain profile** (recommended for local development):
+
+   ```bash
+   xcrun notarytool store-credentials "velocity-report" \
+     --apple-id "<APPLE_ID>" --team-id "<TEAM_ID>" \
+     --password "<APP-SPECIFIC-PASSWORD>"
+   ```
+
+   **Option B — App Store Connect API key** (recommended for CI):
+
+   ```bash
+   export NOTARY_KEY=/path/to/AuthKey_XXXX.p8
+   export NOTARY_KEY_ID=XXXXXXXXXX
+   export NOTARY_ISSUER=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+   ```
+
+### Configuration
+
+| Variable            | Default                    | Description                              |
+| ------------------- | -------------------------- | ---------------------------------------- |
+| `CODESIGN_IDENTITY` | `Developer ID Application` | Codesign identity name                   |
+| `NOTARY_PROFILE`    | `velocity-report`          | Keychain profile for `notarytool`        |
+| `NOTARY_KEY`        | _(unset)_                  | Path to App Store Connect API key (.p8)  |
+| `NOTARY_KEY_ID`     | _(unset)_                  | API key ID (used with `NOTARY_KEY`)      |
+| `NOTARY_ISSUER`     | _(unset)_                  | API issuer UUID (used with `NOTARY_KEY`) |
+
+### CI Secrets
+
+When configured, the `🍎 macOS CI` workflow signs and notarises
+automatically on tagged releases. Required GitHub Actions secrets:
+
+| Secret                       | Description                                     |
+| ---------------------------- | ----------------------------------------------- |
+| `MACOS_CERTIFICATE`          | Base64-encoded Developer ID `.p12` certificate  |
+| `MACOS_CERTIFICATE_PASSWORD` | Password for the `.p12` file                    |
+| `NOTARY_KEY`                 | Contents of the App Store Connect API key (.p8) |
+| `NOTARY_KEY_ID`              | API key ID                                      |
+| `NOTARY_ISSUER`              | API issuer UUID                                 |
+
+If the secrets are not set, CI still produces an unsigned DMG artefact.
+
+### Common Failure Modes
+
+| Symptom                                                    | Cause                                     | Fix                                         |
+| ---------------------------------------------------------- | ----------------------------------------- | ------------------------------------------- |
+| `identity not found`                                       | Certificate not in keychain               | Install Developer ID cert from Apple portal |
+| `errSecInternalComponent`                                  | Keychain locked or restricted             | `security unlock-keychain login.keychain`   |
+| `Hardened Runtime not enabled`                             | Missing `--options runtime`               | Already set by `codesign-notarise.sh`       |
+| `Unsigned nested code`                                     | Framework/dylib not signed                | Script signs nested code inside-out         |
+| `Invalid signature (code or signature have been modified)` | App modified after signing                | Re-run `make sign-mac` before packaging     |
+| `Notarisation credentials not found`                       | Missing profile/key                       | Run `store-credentials` or set env vars     |
+| `Package Invalid` / rejected by Apple                      | Hardened Runtime issue or unsigned binary | Check `xcrun notarytool log` for details    |

--- a/tools/visualiser-macos/BUILDING.md
+++ b/tools/visualiser-macos/BUILDING.md
@@ -137,8 +137,8 @@ Individual steps can also be run separately:
 make build-mac          # Build the .app
 make sign-mac           # Codesign with Developer ID (Hardened Runtime)
 make dmg-mac-release    # Package into DMG
-make notarise-mac DMG_SUFFIX=   # Submit, wait, staple
-make verify-mac   DMG_SUFFIX=   # codesign + spctl + stapler checks
+make notarise-mac       # Submit release DMG, wait, staple
+make verify-mac         # codesign + spctl + stapler checks
 ```
 
 ### One-Time Local Setup
@@ -167,13 +167,14 @@ make verify-mac   DMG_SUFFIX=   # codesign + spctl + stapler checks
 
 ### Configuration
 
-| Variable            | Default                    | Description                              |
-| ------------------- | -------------------------- | ---------------------------------------- |
-| `CODESIGN_IDENTITY` | `Developer ID Application` | Codesign identity name                   |
-| `NOTARY_PROFILE`    | `velocity-report`          | Keychain profile for `notarytool`        |
-| `NOTARY_KEY`        | _(unset)_                  | Path to App Store Connect API key (.p8)  |
-| `NOTARY_KEY_ID`     | _(unset)_                  | API key ID (used with `NOTARY_KEY`)      |
-| `NOTARY_ISSUER`     | _(unset)_                  | API issuer UUID (used with `NOTARY_KEY`) |
+| Variable                | Default                    | Description                              |
+| ----------------------- | -------------------------- | ---------------------------------------- |
+| `CODESIGN_IDENTITY`     | `Developer ID Application` | Codesign identity name                   |
+| `NOTARY_PROFILE`        | `velocity-report`          | Keychain profile for `notarytool`        |
+| `NOTARY_KEY`            | _(unset)_                  | Path to App Store Connect API key (.p8)  |
+| `NOTARY_KEY_ID`         | _(unset)_                  | API key ID (used with `NOTARY_KEY`)      |
+| `NOTARY_ISSUER`         | _(unset)_                  | API issuer UUID (used with `NOTARY_KEY`) |
+| `VISUALISER_NOTARY_DMG` | release DMG path           | DMG path for notarise/verify targets     |
 
 ### CI Secrets
 

--- a/tools/visualiser-macos/BUILDING.md
+++ b/tools/visualiser-macos/BUILDING.md
@@ -235,6 +235,17 @@ source=Notarized Developer ID
 ✓ All verification checks passed
 ```
 
+To validate a downloaded CI or release DMG without rebuilding locally:
+
+```bash
+make verify-mac-dmg DMG=/path/to/VelocityVisualiser-<VERSION>.dmg
+```
+
+This mounts the DMG read-only, validates the stapled notarisation ticket,
+prints the embedded app's signing authority and Team ID, verifies the app
+signature, and runs Gatekeeper assessment. For non-standard bundles, pass
+`DMG_APP_NAME=<Name>.app`.
+
 ### Configuration
 
 | Variable                     | Default                    | Description                                    |
@@ -246,6 +257,8 @@ source=Notarized Developer ID
 | `NOTARY_KEY_ID`              | _(unset)_                  | API key ID (used with `NOTARY_KEY`)            |
 | `NOTARY_ISSUER`              | _(unset)_                  | API issuer UUID (used with `NOTARY_KEY`)       |
 | `VISUALISER_NOTARY_DMG`      | release DMG path           | DMG path for notarise/verify targets           |
+| `DMG`                        | release DMG path           | Downloaded DMG path for `verify-mac-dmg`       |
+| `DMG_APP_NAME`               | `VelocityVisualiser.app`   | App bundle name inside downloaded DMGs         |
 | `DMG_LAYOUT`                 | `1`                        | Set to `0` to skip Finder layout               |
 | `DMG_LAYOUT_TIMEOUT_SECONDS` | `30`                       | Finder layout timeout before packaging goes on |
 

--- a/tools/visualiser-macos/BUILDING.md
+++ b/tools/visualiser-macos/BUILDING.md
@@ -90,10 +90,10 @@ This generates both Go and Swift files. The Swift files are placed in:
 To package VelocityVisualiser.app into a versioned DMG for distribution:
 
 ```bash
-# From repository root — builds the app then creates the DMG
+# From repository root
 make build-mac
-make dmg-mac            # dev: <DATETIME>-VelocityVisualiser-<DEV_VERSION>-<SHA>.dmg
-make dmg-mac-release    # release: VelocityVisualiser-<VERSION>.dmg
+make dmg-mac            # dev DMG: <DATETIME>-VelocityVisualiser-<DEV_VERSION>-<SHA>.dmg
+make dmg-mac-release    # release DMG: VelocityVisualiser-<VERSION>.dmg
 ```
 
 By default `dmg-mac` prepends a UTC timestamp and appends the short git SHA
@@ -101,16 +101,23 @@ to the filename (e.g. `20260407T142345Z-VelocityVisualiser-0.5.1.pre1-a1b2c3d.dm
 so that development builds are sortable and traceable. Use `dmg-mac-release`
 to produce a clean release filename without the date or SHA.
 
+Both targets build the app only if `VelocityVisualiser.app` is missing; this
+lets the signed release path package the already-signed app without rebuilding
+and invalidating the Developer ID signature.
+
 The output DMG is written to `tools/visualiser-macos/build/`:
 
 - `make dmg-mac` → `<DATETIME>-VelocityVisualiser-<DEV_VERSION>-<SHA>.dmg`
 - `make dmg-mac-release` → `VelocityVisualiser-<VERSION>.dmg`
 
-The DMG opens in a small Finder window with VelocityVisualiser.app on the
-left, a `Getting Started.txt` guide in the centre, and an Applications
-shortcut on the right for drag-and-drop installation. The layout is
-configured by `scripts/create-dmg.sh`. The version is read from the
-`VERSION` variable in the Makefile.
+The DMG opens in a small Finder window with VelocityVisualiser.app on the left,
+a `Getting Started.txt` guide in the centre, and an Applications shortcut on
+the right for drag-and-drop installation. The layout is configured by
+`scripts/create-dmg.sh`; Finder automation is best-effort and timeout-bounded
+so local privacy prompts or headless runners cannot hang packaging. Override
+the timeout with `DMG_LAYOUT_TIMEOUT_SECONDS=<seconds>`, or set `DMG_LAYOUT=0`
+to skip Finder layout entirely. The version is read from the `VERSION` variable
+in the Makefile.
 
 The Getting Started guide (`tools/visualiser-macos/Getting Started.txt`)
 covers server setup, connecting the app, keyboard shortcuts, and basic
@@ -141,11 +148,38 @@ make notarise-mac       # Submit release DMG, wait, staple
 make verify-mac         # codesign + spctl + stapler checks
 ```
 
+When running the steps manually, sign after the final build and package that
+same app bundle. Do not run a build command between `make sign-mac` and
+`make dmg-mac-release`; rebuilding replaces the signed app with a local
+development signature. `make release-mac` handles the order correctly.
+
 ### One-Time Local Setup
 
 1. **Install a Developer ID Application certificate** from the
    [Apple Developer portal](https://developer.apple.com/account/resources/certificates/list)
-   into your login keychain.
+   into your login or System keychain.
+
+   Generate the certificate request on the Mac that will sign the release, or
+   import a `.p12` that contains both the certificate and its private key. A
+   downloaded `.cer` alone is not enough unless Keychain can pair it with the
+   private key from the original certificate-signing request.
+
+   Verify that Keychain has a usable signing identity:
+
+   ```bash
+   security find-identity -v -p codesigning
+   ```
+
+   The output must include a `Developer ID Application: ...` identity. If more
+   than one matching identity appears, pass the SHA-1 hash explicitly:
+
+   ```bash
+   make release-mac CODESIGN_IDENTITY=<SHA1_FROM_FIND_IDENTITY>
+   ```
+
+   On the first signing run, macOS may prompt for private-key access. Approve
+   `codesign`; choosing **Always Allow** avoids repeated prompts during nested
+   framework signing.
 
 2. **Store notarisation credentials** (choose one):
 
@@ -157,6 +191,14 @@ make verify-mac         # codesign + spctl + stapler checks
      --password "<APP-SPECIFIC-PASSWORD>"
    ```
 
+   Check the profile without submitting a new build:
+
+   ```bash
+   xcrun notarytool history \
+     --keychain-profile velocity-report \
+     --keychain ~/Library/Keychains/login.keychain-db
+   ```
+
    **Option B — App Store Connect API key** (recommended for CI):
 
    ```bash
@@ -165,16 +207,47 @@ make verify-mac         # codesign + spctl + stapler checks
    export NOTARY_ISSUER=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
    ```
 
+Keep all signing and notarisation credentials in Keychain, local environment
+variables, or GitHub Actions secrets. Do not commit certificates, private keys,
+notary profile exports, `.p8` API keys, or app-specific passwords to the repo.
+
+### Verified Local Release Path
+
+The first successful local notarised DMG run was completed on August 10, 2026
+with this sequence:
+
+```bash
+security find-identity -v -p codesigning
+xcrun notarytool history --keychain-profile velocity-report \
+  --keychain ~/Library/Keychains/login.keychain-db
+make build-mac
+make sign-mac CODESIGN_IDENTITY=<Developer ID Application SHA1>
+make dmg-mac-release
+make notarise-mac
+make verify-mac
+```
+
+Expected final verification:
+
+```text
+source=Notarized Developer ID
+✓ Staple valid
+✓ All verification checks passed
+```
+
 ### Configuration
 
-| Variable                | Default                    | Description                              |
-| ----------------------- | -------------------------- | ---------------------------------------- |
-| `CODESIGN_IDENTITY`     | `Developer ID Application` | Codesign identity name                   |
-| `NOTARY_PROFILE`        | `velocity-report`          | Keychain profile for `notarytool`        |
-| `NOTARY_KEY`            | _(unset)_                  | Path to App Store Connect API key (.p8)  |
-| `NOTARY_KEY_ID`         | _(unset)_                  | API key ID (used with `NOTARY_KEY`)      |
-| `NOTARY_ISSUER`         | _(unset)_                  | API issuer UUID (used with `NOTARY_KEY`) |
-| `VISUALISER_NOTARY_DMG` | release DMG path           | DMG path for notarise/verify targets     |
+| Variable                     | Default                    | Description                                    |
+| ---------------------------- | -------------------------- | ---------------------------------------------- |
+| `CODESIGN_IDENTITY`          | `Developer ID Application` | Codesign identity name or SHA-1 hash           |
+| `NOTARY_PROFILE`             | `velocity-report`          | Keychain profile for `notarytool`              |
+| `NOTARY_KEYCHAIN`            | login keychain             | Keychain path used with `NOTARY_PROFILE`       |
+| `NOTARY_KEY`                 | _(unset)_                  | Path to App Store Connect API key (.p8)        |
+| `NOTARY_KEY_ID`              | _(unset)_                  | API key ID (used with `NOTARY_KEY`)            |
+| `NOTARY_ISSUER`              | _(unset)_                  | API issuer UUID (used with `NOTARY_KEY`)       |
+| `VISUALISER_NOTARY_DMG`      | release DMG path           | DMG path for notarise/verify targets           |
+| `DMG_LAYOUT`                 | `1`                        | Set to `0` to skip Finder layout               |
+| `DMG_LAYOUT_TIMEOUT_SECONDS` | `30`                       | Finder layout timeout before packaging goes on |
 
 ### CI Secrets
 
@@ -190,15 +263,21 @@ automatically on tagged releases. Required GitHub Actions secrets:
 | `NOTARY_ISSUER`              | API issuer UUID                                 |
 
 If the secrets are not set, CI still produces an unsigned DMG artefact.
+Populate these only in GitHub repository **Settings → Secrets and variables →
+Actions**. Do not put their values in workflow YAML, local docs, issue
+comments, or chat.
 
 ### Common Failure Modes
 
-| Symptom                                                    | Cause                                     | Fix                                         |
-| ---------------------------------------------------------- | ----------------------------------------- | ------------------------------------------- |
-| `identity not found`                                       | Certificate not in keychain               | Install Developer ID cert from Apple portal |
-| `errSecInternalComponent`                                  | Keychain locked or restricted             | `security unlock-keychain login.keychain`   |
-| `Hardened Runtime not enabled`                             | Missing `--options runtime`               | Already set by `codesign-notarise.sh`       |
-| `Unsigned nested code`                                     | Framework/dylib not signed                | Script signs nested code inside-out         |
-| `Invalid signature (code or signature have been modified)` | App modified after signing                | Re-run `make sign-mac` before packaging     |
-| `Notarisation credentials not found`                       | Missing profile/key                       | Run `store-credentials` or set env vars     |
-| `Package Invalid` / rejected by Apple                      | Hardened Runtime issue or unsigned binary | Check `xcrun notarytool log` for details    |
+| Symptom                                                    | Cause                                      | Fix                                                                          |
+| ---------------------------------------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------- |
+| `0 valid identities found`                                 | Certificate lacks matching private key     | Recreate from a CSR on this Mac or import `.p12`                             |
+| `identity not found`                                       | Certificate not in searched keychain       | Install Developer ID Application identity or pass `CODESIGN_IDENTITY=<SHA1>` |
+| `errSecInternalComponent`                                  | Keychain locked or restricted              | `security unlock-keychain login.keychain`                                    |
+| `codesign` appears to hang                                 | Private-key access prompt is waiting       | Approve `codesign` in the macOS Keychain prompt                              |
+| `Hardened Runtime not enabled`                             | Missing `--options runtime`                | Already set by `codesign-notarise.sh`                                        |
+| `Unsigned nested code`                                     | Framework/dylib not signed                 | Script signs nested code inside-out                                          |
+| `Invalid signature (code or signature have been modified)` | App modified after signing                 | Re-run `make sign-mac` before packaging                                      |
+| `Notarisation credentials not found`                       | Missing profile/key                        | Run `store-credentials` or set env vars                                      |
+| `Package Invalid` / rejected by Apple                      | Hardened Runtime issue or unsigned binary  | Check `xcrun notarytool log` for details                                     |
+| DMG packaging stalls during Finder layout                  | Finder automation prompt or unavailable UI | Wait for timeout, set `DMG_LAYOUT=0`, or lower `DMG_LAYOUT_TIMEOUT_SECONDS`  |

--- a/tools/visualiser-macos/BUILDING.md
+++ b/tools/visualiser-macos/BUILDING.md
@@ -254,18 +254,25 @@ source=Notarized Developer ID
 When configured, the `🍎 macOS CI` workflow signs and notarises
 automatically on tagged releases. Required GitHub Actions secrets:
 
-| Secret                       | Description                                     |
-| ---------------------------- | ----------------------------------------------- |
-| `MACOS_CERTIFICATE`          | Base64-encoded Developer ID `.p12` certificate  |
-| `MACOS_CERTIFICATE_PASSWORD` | Password for the `.p12` file                    |
-| `NOTARY_KEY`                 | Contents of the App Store Connect API key (.p8) |
-| `NOTARY_KEY_ID`              | API key ID                                      |
-| `NOTARY_ISSUER`              | API issuer UUID                                 |
+| Secret                       | Source                                                                | GitHub destination            |
+| ---------------------------- | --------------------------------------------------------------------- | ----------------------------- |
+| `MACOS_CERTIFICATE`          | Base64 export of a Developer ID Application `.p12` certificate bundle | Repository **Actions** secret |
+| `MACOS_CERTIFICATE_PASSWORD` | Password chosen when exporting the `.p12` from Keychain Access        | Repository **Actions** secret |
+| `NOTARY_KEY`                 | Contents of the App Store Connect API key file, `AuthKey_<KEY_ID>.p8` | Repository **Actions** secret |
+| `NOTARY_KEY_ID`              | App Store Connect API key ID shown beside the downloaded `.p8` key    | Repository **Actions** secret |
+| `NOTARY_ISSUER`              | App Store Connect issuer ID for the API key                           | Repository **Actions** secret |
 
-If the secrets are not set, CI still produces an unsigned DMG artefact.
-Populate these only in GitHub repository **Settings → Secrets and variables →
-Actions**. Do not put their values in workflow YAML, local docs, issue
-comments, or chat.
+The CI release job has two valid modes:
+
+- With all five secrets configured, it signs the app with Developer ID,
+  notarises the DMG, staples the ticket, verifies signatures, and uploads
+  `VelocityVisualiser-dmg`.
+- With none of the five secrets configured, it still produces a packaging
+  smoke-test DMG, but renames the file and artifact with `UNSIGNED`.
+
+Partial configuration is treated as an error. Populate these only in GitHub
+repository **Settings → Secrets and variables → Actions**. Do not put their
+values in workflow YAML, local docs, issue comments, or chat.
 
 ### Common Failure Modes
 

--- a/tools/visualiser-macos/README.md
+++ b/tools/visualiser-macos/README.md
@@ -14,9 +14,9 @@ This is a SwiftUI application that connects to the Go LiDAR pipeline via gRPC an
 
 ## Requirements
 
-- macOS 14.0+ (Sonoma)
+- macOS 15.0+ (Sequoia)
 - Apple Silicon (M1/M2/M3) or Intel with Metal support
-- Xcode 15.0+
+- Xcode 16.0+
 
 ## Building
 
@@ -29,8 +29,8 @@ For detailed build instructions and troubleshooting, see [BUILDING.md](BUILDING.
 
 ### Prerequisites
 
-- macOS 14.0+ (Sonoma)
-- Xcode 15.0+
+- macOS 15.0+ (Sequoia)
+- Xcode 16.0+
 
 ## Usage
 
@@ -65,6 +65,36 @@ open tools/visualiser-macos/build/Build/Products/Release/VelocityVisualiser.app
 1. Click on a track in the 3D view to select it
 2. Use the Label panel (press L) to assign a class
 3. Export labels via File → Export Labels (⌘E)
+
+## Release Distribution
+
+VelocityVisualiser GitHub releases ship as a signed and notarised DMG:
+
+```bash
+make release-mac
+```
+
+Local release signing requires a `Developer ID Application` identity with its
+private key in Keychain, plus a `notarytool` credential profile named
+`velocity-report` or App Store Connect API-key environment variables. The
+successful local release path is:
+
+```bash
+security find-identity -v -p codesigning
+xcrun notarytool history --keychain-profile velocity-report \
+  --keychain ~/Library/Keychains/login.keychain-db
+make build-mac
+make sign-mac CODESIGN_IDENTITY=<Developer ID Application SHA1>
+make dmg-mac-release
+make notarise-mac
+make verify-mac
+```
+
+Store certificates, private keys, app-specific passwords, and App Store
+Connect API keys only in Keychain, local environment variables, or GitHub
+Actions repository secrets. Do not commit credential material to this repo.
+Detailed setup and CI secret names are in the
+[build guide](BUILDING.md#signing-notarisation-and-distribution).
 
 ## Keyboard shortcuts
 


### PR DESCRIPTION
# Purpose

This pull request introduces a complete, automated pipeline for codesigning, notarising, and verifying the macOS visualiser app and its DMG, both for local development and CI. It adds new Makefile targets, a robust shell script for handling all steps, workflow enhancements for CI, and comprehensive documentation for setup and troubleshooting.

# Changes

**Build & Release Automation:**

* Added new Makefile targets: `sign-mac`, `notarise-mac`, `verify-mac`, and `release-mac` to automate codesigning, notarisation, verification, and full release of the macOS visualiser app and DMG. These targets use a new script to handle the required steps and checks. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R27-R30) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L245-R249) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R332-R356)

* Introduced `scripts/codesign-notarise.sh`, a comprehensive script that handles codesigning the app, submitting the DMG for notarisation, stapling the notarisation ticket, and verifying signatures and staples. It supports both local and CI authentication methods for notarisation.

**CI/CD Integration:**

* Enhanced the GitHub Actions workflow (`.github/workflows/mac-ci.yml`) to automatically import the Developer ID certificate, codesign the app, notarise and staple the DMG, and verify signatures when the relevant secrets are set. This ensures that release artefacts are securely signed and notarised in CI. [[1]](diffhunk://#diff-e936dda3f0fcf39f2aa293965a09a47487238e273549530644fada59b18820bfR138-R157) [[2]](diffhunk://#diff-e936dda3f0fcf39f2aa293965a09a47487238e273549530644fada59b18820bfR171-R193)

**Documentation:**

* Expanded `tools/visualiser-macos/BUILDING.md` with a new section detailing the codesigning and notarisation process, including one-time setup instructions, configuration variables, CI secrets, and troubleshooting for common issues.

# Checklist

- [ ] Uses British English spelling/wording where applicable.
- [ ] Design is confirmed and aligns with `DESIGN.md`.
- [ ] Any maths/derived values are valid and up to date.
- [ ] Version has been bumped where required.
- [ ] Documentation is up to date.
- [ ] `README.md` is up to date.
- [ ] `docs/DEVLOG.md` is up to date.
