### PR TITLE
[js] add symlink (worktree) for vite

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,5 +1,7 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
+import { realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { defineConfig, type Plugin } from 'vite';
 
 /**
@@ -26,6 +28,11 @@ function svelteVirtualCssFix(): Plugin {
 
 export default defineConfig({
 	server: {
+		fs: {
+			// In git worktrees, node_modules may be symlinked to the main
+			// repo. Resolve the real path so Vite allows serving them.
+			allow: [realpathSync(resolve('node_modules'))]
+		},
 		proxy: {
 			'/api/lidar': 'http://localhost:8081',
 			'/api': 'http://localhost:8080'


### PR DESCRIPTION
# Purpose


This pull request updates the Vite configuration to improve compatibility with Git worktrees by ensuring that symlinked `node_modules` directories are correctly resolved. This prevents issues where Vite would otherwise block access to dependencies when working in certain repository setups.


# Changes

Configuration improvements for Git worktrees:

* Updated the Vite server configuration in `vite.config.ts` to resolve the real path of the `node_modules` directory using `realpathSync` and `resolve`, allowing Vite to serve dependencies even if `node_modules` is symlinked [[1]](diffhunk://#diff-9430906049744cbbfe5d0b382b2466843a42cfebf755ff86fec850b0712258efR3-R4) [[2]](diffhunk://#diff-9430906049744cbbfe5d0b382b2466843a42cfebf755ff86fec850b0712258efR31-R35).


# Checklist

- [ ] Uses British English spelling/wording where applicable.
- [ ] Design is confirmed and aligns with `DESIGN.md`.
- [ ] Any maths/derived values are valid and up to date.
- [ ] Version has been bumped where required.
- [ ] Documentation is up to date.
- [ ] `README.md` is up to date.
- [ ] `docs/DEVLOG.md` is up to date.
