### PR TITLE
[img] separate velocity service account from login user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ help:
 # =============================================================================
 # VERSION INFORMATION
 # =============================================================================
-VERSION := 0.5.1-pre2
+VERSION := 0.5.1-pre3
 GIT_SHA := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 GIT_SHA_SHORT := $(shell printf '%.7s' '$(GIT_SHA)')
 BUILD_TIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/image/config
+++ b/image/config
@@ -1,7 +1,7 @@
 IMG_NAME=velocity-report
 RELEASE=bookworm
 TARGET_HOSTNAME=velocity
-FIRST_USER_NAME=velocity
+FIRST_USER_NAME=pi
 FIRST_USER_PASS=report
 DISABLE_FIRST_BOOT_USER_RENAME=1
 # SSH enabled for initial setup. The device is local-network-only (no

--- a/image/os-list-velocity.json
+++ b/image/os-list-velocity.json
@@ -33,7 +33,7 @@
   "os_list": [
     {
       "name": "velocity.report",
-      "description": "Privacy-first traffic monitoring for neighbourhood change-makers. Radar, PDF reporting, and web dashboard. Important: in Raspberry Pi Imager OS Customisation, leave the username as 'velocity' (default), the system service runs under this account.",
+      "description": "Privacy-first traffic monitoring for neighbourhood change-makers. Radar, PDF reporting, and web dashboard.",
       "url": "https://github.com/banshee-data/velocity.report/releases/download/v0.5.1-pre1/2026-04-08-093248-velocity-report.img.xz",
       "extract_size": 2625634304,
       "extract_sha256": "f6355be83d780be546d1d69e8d13c10ec3c79d0b5210de31116873f880ba812a",

--- a/image/scripts/build-image.sh
+++ b/image/scripts/build-image.sh
@@ -16,7 +16,7 @@
 # Options:
 #   --skip-binaries   Reuse binaries from a previous build
 #   --host-build      Build binaries with the host Go toolchain (no Docker compile)
-#   --ssh-key <path>  Install an SSH public key for the velocity user
+#   --ssh-key <path>  Install an SSH public key for the login user
 
 set -euo pipefail
 
@@ -309,7 +309,7 @@ cp -r "$BINARIES_DIR" "$PIGEN_DIR/velocity-binaries"
 if [[ -n "$SSH_KEY_PATH" ]]; then
     SSH_DEST="$PIGEN_DIR/stage-velocity/03-velocity-config/files/authorized_keys"
     cp "$SSH_KEY_PATH" "$SSH_DEST"
-    log_info "SSH public key staged for velocity user"
+    log_info "SSH public key staged for login user"
 fi
 
 # ---------------------------------------------------------------------------

--- a/image/stage-velocity/02-velocity-python/00-run.sh
+++ b/image/stage-velocity/02-velocity-python/00-run.sh
@@ -9,6 +9,12 @@ install -d "${ROOTFS_DIR}/opt/velocity-report/tools/pdf-generator"
 cp -r files/pdf-generator/* "${ROOTFS_DIR}/opt/velocity-report/tools/pdf-generator/"
 
 on_chroot << 'CHEOF'
+# Create the velocity system account early — stage 03 also guards this with
+# an `id` check, but stage 02 needs the user for chown below.
+if ! id velocity >/dev/null 2>&1; then
+    useradd --system --home-dir /var/lib/velocity-report --shell /usr/sbin/nologin velocity
+fi
+
 mkdir -p /opt/velocity-report/tools
 
 # Create shared Python venv

--- a/image/stage-velocity/03-velocity-config/00-run.sh
+++ b/image/stage-velocity/03-velocity-config/00-run.sh
@@ -3,11 +3,13 @@
 # configure serial port, and install udev rules.
 
 on_chroot << 'CHEOF'
-# The login user 'velocity' is created by pi-gen stage2 (FIRST_USER_NAME).
-# We reuse it as the service user so there is one account for both
-# interactive login and the systemd service.
-
-# Add velocity user to dialout group for serial port access
+# Create the velocity system account — a non-login service user that owns
+# the data directory and runs the systemd service.  This account is immune
+# to Raspberry Pi Imager's OS Customisation user-rename because it is a
+# system account, not FIRST_USER_NAME.
+if ! id velocity >/dev/null 2>&1; then
+    useradd --system --home-dir /var/lib/velocity-report --shell /usr/sbin/nologin velocity
+fi
 usermod -aG dialout velocity
 
 # Ensure data directory exists with correct ownership
@@ -17,20 +19,19 @@ chown velocity:velocity /var/lib/velocity-report
 # Create config directory and copy tuning defaults
 mkdir -p /opt/velocity-report/config
 
-# Grant velocity user passwordless sudo for specific commands only.
-# pi-gen stage2's 010_pi-nopasswd may reference the 'pi' user or be
-# absent entirely depending on the packages installed.  Create our own
-# entry scoped to the commands the MOTD, shell aliases, and velocity-ctl
-# actually need.
+# Grant the interactive login user passwordless sudo for service management.
+# FIRST_USER_NAME is set in image/config (default: pi).  Hardcoded here
+# because the on_chroot heredoc is single-quoted to preserve sudoers
+# backslash continuations.
 #
 # Commands:
-#   getent shadow velocity  — MOTD default-password check
+#   getent shadow *         — MOTD default-password check
 #   systemctl *             — shell aliases (start/stop/restart)
 #   velocity-ctl            — on-device management tool (runs as root)
 #   velocity-report migrate — database migrations invoked by velocity-ctl
 cat > /etc/sudoers.d/020_velocity-nopasswd <<'SUDOEOF'
-velocity ALL=(root) NOPASSWD: \
-    /usr/bin/getent shadow velocity, \
+pi ALL=(root) NOPASSWD: \
+    /usr/bin/getent shadow *, \
     /usr/bin/systemctl start velocity-report.service, \
     /usr/bin/systemctl stop velocity-report.service, \
     /usr/bin/systemctl restart velocity-report.service, \
@@ -41,6 +42,9 @@ velocity ALL=(root) NOPASSWD: \
     /usr/local/bin/velocity-report migrate *
 SUDOEOF
 chmod 440 /etc/sudoers.d/020_velocity-nopasswd
+
+# Add login user to velocity group for read access to sensor data
+usermod -aG velocity pi
 CHEOF
 
 # Install tuning defaults
@@ -124,14 +128,12 @@ fi
 # Suppress the default Debian MOTD so ours is the only one shown.
 : > "${ROOTFS_DIR}/etc/motd"
 
-# Install SSH authorized_keys for velocity user (if provided via --ssh-key)
+# Install SSH authorized_keys for login user (if provided via --ssh-key)
 if [ -f files/authorized_keys ]; then
-    install -d -m 700 "${ROOTFS_DIR}/home/velocity/.ssh"
+    install -d -m 700 "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.ssh"
     install -m 600 files/authorized_keys \
-        "${ROOTFS_DIR}/home/velocity/.ssh/authorized_keys"
-    on_chroot << 'CHEOF'
-chown -R velocity:velocity /home/velocity/.ssh
-CHEOF
+        "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.ssh/authorized_keys"
+    chown -R 1000:1000 "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.ssh"
 fi
 
 # Configure UART and SPI overlays for Waveshare RS232/485 HAT (SC16IS752)
@@ -160,6 +162,6 @@ fi
 # userconf-pi package may install.  This runs before export-image, so
 # export-image's own cleanup (removing piwiz.desktop) still applies.
 on_chroot << 'CHEOF'
-cancel-rename velocity 2>/dev/null || true
+cancel-rename pi 2>/dev/null || true
 CHEOF
 rm -f "${ROOTFS_DIR}/etc/systemd/system/getty@tty1.service.d/userconf.conf"

--- a/image/stage-velocity/03-velocity-config/00-run.sh
+++ b/image/stage-velocity/03-velocity-config/00-run.sh
@@ -25,13 +25,13 @@ mkdir -p /opt/velocity-report/config
 # backslash continuations.
 #
 # Commands:
-#   getent shadow *         — MOTD default-password check
+#   getent shadow pi        — MOTD default-password check
 #   systemctl *             — shell aliases (start/stop/restart)
 #   velocity-ctl            — on-device management tool (runs as root)
 #   velocity-report migrate — database migrations invoked by velocity-ctl
 cat > /etc/sudoers.d/020_velocity-nopasswd <<'SUDOEOF'
 pi ALL=(root) NOPASSWD: \
-    /usr/bin/getent shadow *, \
+    /usr/bin/getent shadow pi, \
     /usr/bin/systemctl start velocity-report.service, \
     /usr/bin/systemctl stop velocity-report.service, \
     /usr/bin/systemctl restart velocity-report.service, \
@@ -133,7 +133,9 @@ if [ -f files/authorized_keys ]; then
     install -d -m 700 "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.ssh"
     install -m 600 files/authorized_keys \
         "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.ssh/authorized_keys"
-    chown -R 1000:1000 "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.ssh"
+    on_chroot <<CHEOF
+chown -R "${FIRST_USER_NAME}:${FIRST_USER_NAME}" "/home/${FIRST_USER_NAME}/.ssh"
+CHEOF
 fi
 
 # Configure UART and SPI overlays for Waveshare RS232/485 HAT (SC16IS752)

--- a/image/stage-velocity/03-velocity-config/files/velocity-motd.sh
+++ b/image/stage-velocity/03-velocity-config/files/velocity-motd.sh
@@ -9,7 +9,6 @@
 [ -t 0 ] || return 0
 
 DEFAULT_PASS="report"
-VELOCITY_USER="velocity"
 
 # Build metadata stamped at image creation time.
 BUILD_INFO_FILE="/etc/velocity-report-build"
@@ -24,7 +23,7 @@ VR_GIT_SHA="${VR_GIT_SHA:-unknown}"
 # --- Check whether the default password is still in use ----------------------
 #
 # Read the stored hash from shadow via sudo and compare against the
-# default password.  The velocity user has a NOPASSWD sudoers entry
+# default password.  The login user has a NOPASSWD sudoers entry
 # for getent (installed by stage-velocity/03-velocity-config).
 #
 # If sudo or getent fails, assume the password is STILL default and
@@ -32,7 +31,7 @@ VR_GIT_SHA="${VR_GIT_SHA:-unknown}"
 
 password_is_default() {
     local stored
-    stored=$(sudo -n getent shadow "$VELOCITY_USER" 2>/dev/null | cut -d: -f2)
+    stored=$(sudo -n getent shadow "$USER" 2>/dev/null | cut -d: -f2)
     [ -z "$stored" ] && return 0   # Cannot verify — assume default
 
     python3 -c "

--- a/public_html/package.json
+++ b/public_html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "velocity.report",
-  "version": "0.5.1-pre2",
+  "version": "0.5.1-pre3",
   "description": "https://velocity.report",
   "main": "index.js",
   "scripts": {

--- a/tools/pdf-generator/pyproject.toml
+++ b/tools/pdf-generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velocity-report-pdf-generator"
-version = "0.5.1-pre2"
+version = "0.5.1-pre3"
 description = "PDF report generator for velocity.report Go application"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tools/visualiser-macos/VelocityVisualiser.xcodeproj/project.pbxproj
+++ b/tools/visualiser-macos/VelocityVisualiser.xcodeproj/project.pbxproj
@@ -453,7 +453,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.1-pre2;
+				MARKETING_VERSION = 0.5.1-pre3;
 				PRODUCT_BUNDLE_IDENTIFIER = report.velocity.VelocityVisualiser;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -485,7 +485,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5.1-pre2;
+				MARKETING_VERSION = 0.5.1-pre3;
 				PRODUCT_BUNDLE_IDENTIFIER = report.velocity.VelocityVisualiser;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -506,7 +506,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.5.1-pre2;
+				MARKETING_VERSION = 0.5.1-pre3;
 				PRODUCT_BUNDLE_IDENTIFIER = report.velocity.VelocityVisualiserTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -526,7 +526,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.5.1-pre2;
+				MARKETING_VERSION = 0.5.1-pre3;
 				PRODUCT_BUNDLE_IDENTIFIER = report.velocity.VelocityVisualiserTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -544,7 +544,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.5.1-pre2;
+				MARKETING_VERSION = 0.5.1-pre3;
 				PRODUCT_BUNDLE_IDENTIFIER = report.velocity.VelocityVisualiserUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -562,7 +562,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.5.1-pre2;
+				MARKETING_VERSION = 0.5.1-pre3;
 				PRODUCT_BUNDLE_IDENTIFIER = report.velocity.VelocityVisualiserUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "velocity.report-web",
 	"private": true,
-	"version": "0.5.1-pre2",
+	"version": "0.5.1-pre3",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
# Purpose

The velocity system account is now created with useradd --system during the pi-gen build, making it immune to Raspberry Pi Imager's OS Customisation user-rename.  FIRST_USER_NAME changes to 'pi' (standard RPi default) — the interactive login user is decoupled from the service account.

# Changes

- image/config: FIRST_USER_NAME=pi (was velocity)
- 03-velocity-config/00-run.sh: explicit useradd --system for velocity, sudoers and group membership target login user (pi), SSH keys install to login user home
- velocity-motd.sh: password check uses $USER not hardcoded velocity
- os-list-velocity.json: remove 'leave username as velocity' instruction
- build-image.sh: SSH key help text updated


# Checklist

- [ ] Uses British English spelling/wording where applicable.
- [ ] Design is confirmed and aligns with `DESIGN.md`.
- [ ] Any maths/derived values are valid and up to date.
- [ ] Version has been bumped where required.
- [ ] Documentation is up to date.
- [ ] `README.md` is up to date.
- [ ] `docs/DEVLOG.md` is up to date.
