### PR TITLE
Fix Raspberry Pi image CI by installing qemu-user-static

### DIFF
--- a/.github/actions/setup-qemu-pigen/action.yml
+++ b/.github/actions/setup-qemu-pigen/action.yml
@@ -1,0 +1,12 @@
+name: "Setup qemu-user-static for pi-gen"
+description: "Installs the host ARM64 emulator required by pi-gen on GitHub runners"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install qemu-user-static
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y qemu-user-static
+        qemu-aarch64-static --version

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -170,11 +170,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install qemu-user-static for pi-gen
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-          qemu-aarch64-static --version
+      - name: Setup qemu-user-static for pi-gen
+        uses: ./.github/actions/setup-qemu-pigen
 
       - name: Setup Node.js with pnpm (web)
         uses: ./.github/actions/setup-node-pnpm
@@ -239,11 +236,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install qemu-user-static for pi-gen
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-          qemu-aarch64-static --version
+      - name: Setup qemu-user-static for pi-gen
+        uses: ./.github/actions/setup-qemu-pigen
 
       - name: Setup Node.js with pnpm (web)
         uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -170,6 +170,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install qemu-user-static for pi-gen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+          qemu-aarch64-static --version
+
       - name: Setup Node.js with pnpm (web)
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -232,6 +238,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install qemu-user-static for pi-gen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+          qemu-aarch64-static --version
 
       - name: Setup Node.js with pnpm (web)
         uses: ./.github/actions/setup-node-pnpm


### PR DESCRIPTION
## Summary
- install `qemu-user-static` before running `pi-gen` in the release image workflow
- apply the same setup in the manual image build job so both paths have the required `qemu-aarch64-static` binary
- verify the installed emulator is available before starting the image build

## Testing
- Not run (not requested)