### PR TITLE
[ci] fix version issues

### DIFF
--- a/.github/workflows/lint-autofix.yml
+++ b/.github/workflows/lint-autofix.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          version: 10
 
       - name: Install web dependencies
         run: cd web && pnpm install --frozen-lockfile

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ velocity-deploy*
 /deploy
 mock_serial_port*
 /radar
-pcap-analyse
+/pcap-analyse
 
 # =============================================================================
 # Pi Image Build (pi-gen)

--- a/cmd/tools/pcap-analyse/collect_test.go
+++ b/cmd/tools/pcap-analyse/collect_test.go
@@ -1,0 +1,153 @@
+//go:build pcap
+// +build pcap
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/banshee-data/velocity.report/internal/lidar/l5tracks"
+	"github.com/banshee-data/velocity.report/internal/lidar/l6objects"
+)
+
+// makeFrameBuilder returns a minimal analysisFrameBuilder suitable for unit-testing
+// collectTrackResults. Only tracker and classifier are populated; no background
+// model, database, or PCAP I/O is involved.
+func makeFrameBuilder(tracks map[string]*l5tracks.TrackedObject) *analysisFrameBuilder {
+	tracker := l5tracks.NewTracker(l5tracks.DefaultTrackerConfig())
+	tracker.Tracks = tracks
+	return &analysisFrameBuilder{
+		tracker:    tracker,
+		classifier: l6objects.NewTrackClassifier(),
+	}
+}
+
+// newResult returns a zero-valued AnalysisResult ready for collectTrackResults.
+func newResult() *AnalysisResult {
+	return &AnalysisResult{TracksByClass: make(map[string]int)}
+}
+
+func TestCollectTrackResults_ConfirmedCount(t *testing.T) {
+	tracks := map[string]*l5tracks.TrackedObject{
+		"t1": {
+			TrackID: "t1",
+			TrackMeasurement: l5tracks.TrackMeasurement{
+				TrackState:     l5tracks.TrackConfirmed,
+				ObjectClass:    "vehicle",
+				StartUnixNanos: 1_000_000_000,
+				EndUnixNanos:   2_000_000_000,
+			},
+		},
+		"t2": {
+			TrackID: "t2",
+			TrackMeasurement: l5tracks.TrackMeasurement{
+				TrackState:     l5tracks.TrackTentative,
+				ObjectClass:    "vehicle",
+				StartUnixNanos: 1_000_000_000,
+				EndUnixNanos:   2_000_000_000,
+			},
+		},
+	}
+
+	fb := makeFrameBuilder(tracks)
+	result := newResult()
+	collectTrackResults(fb, result)
+
+	if result.TotalTracks != 2 {
+		t.Errorf("TotalTracks: want 2, got %d", result.TotalTracks)
+	}
+	if result.ConfirmedTracks != 1 {
+		t.Errorf("ConfirmedTracks: want 1, got %d", result.ConfirmedTracks)
+	}
+}
+
+func TestCollectTrackResults_TimestampFields(t *testing.T) {
+	const startNanos int64 = 1_700_000_000_000_000_000 // 2023-11-14 22:13:20 UTC
+	const endNanos int64 = 1_700_000_010_000_000_000   // +10 seconds
+
+	tracks := map[string]*l5tracks.TrackedObject{
+		"t1": {
+			TrackID: "t1",
+			TrackMeasurement: l5tracks.TrackMeasurement{
+				TrackState:     l5tracks.TrackConfirmed,
+				ObjectClass:    "vehicle",
+				StartUnixNanos: startNanos,
+				EndUnixNanos:   endNanos,
+			},
+		},
+	}
+
+	fb := makeFrameBuilder(tracks)
+	result := newResult()
+	collectTrackResults(fb, result)
+
+	if len(result.Tracks) != 1 {
+		t.Fatalf("expected 1 track export, got %d", len(result.Tracks))
+	}
+	export := result.Tracks[0]
+
+	wantStart := time.Unix(0, startNanos).Format(time.RFC3339)
+	wantEnd := time.Unix(0, endNanos).Format(time.RFC3339)
+	const wantDuration = 10.0
+
+	if export.StartTime != wantStart {
+		t.Errorf("StartTime: want %q, got %q", wantStart, export.StartTime)
+	}
+	if export.EndTime != wantEnd {
+		t.Errorf("EndTime: want %q, got %q", wantEnd, export.EndTime)
+	}
+	if export.DurationSecs != wantDuration {
+		t.Errorf("DurationSecs: want %v, got %v", wantDuration, export.DurationSecs)
+	}
+}
+
+func TestCollectTrackResults_ZeroTimestamps(t *testing.T) {
+	// A track with no timestamps (zero nanos) should still export without panic.
+	tracks := map[string]*l5tracks.TrackedObject{
+		"t1": {
+			TrackID: "t1",
+			TrackMeasurement: l5tracks.TrackMeasurement{
+				TrackState:  l5tracks.TrackConfirmed,
+				ObjectClass: "other",
+			},
+		},
+	}
+
+	fb := makeFrameBuilder(tracks)
+	result := newResult()
+	collectTrackResults(fb, result)
+
+	if len(result.Tracks) != 1 {
+		t.Fatalf("expected 1 track export, got %d", len(result.Tracks))
+	}
+	export := result.Tracks[0]
+
+	if export.DurationSecs != 0 {
+		t.Errorf("DurationSecs: want 0 for zero timestamps, got %v", export.DurationSecs)
+	}
+}
+
+func TestCollectTrackResults_ClassFallback(t *testing.T) {
+	// A track with no ObjectClass should be labelled "other" in the export.
+	tracks := map[string]*l5tracks.TrackedObject{
+		"t1": {
+			TrackID: "t1",
+			TrackMeasurement: l5tracks.TrackMeasurement{
+				TrackState:       l5tracks.TrackTentative,
+				ObservationCount: 3, // below classifier threshold
+			},
+		},
+	}
+
+	fb := makeFrameBuilder(tracks)
+	result := newResult()
+	collectTrackResults(fb, result)
+
+	if result.Tracks[0].Class != "other" {
+		t.Errorf("Class: want %q, got %q", "other", result.Tracks[0].Class)
+	}
+	if result.TracksByClass["other"] != 1 {
+		t.Errorf("TracksByClass[other]: want 1, got %d", result.TracksByClass["other"])
+	}
+}

--- a/cmd/tools/pcap-analyse/main.go
+++ b/cmd/tools/pcap-analyse/main.go
@@ -841,7 +841,7 @@ func collectTrackResults(frameBuilder *analysisFrameBuilder, result *AnalysisRes
 			classifier.ClassifyAndUpdate(track)
 		}
 
-		if track.State == l5tracks.TrackConfirmed {
+		if track.TrackState == l5tracks.TrackConfirmed {
 			result.ConfirmedTracks++
 		}
 
@@ -855,9 +855,9 @@ func collectTrackResults(frameBuilder *analysisFrameBuilder, result *AnalysisRes
 			TrackID:      track.TrackID,
 			Class:        class,
 			Confidence:   track.ObjectConfidence,
-			StartTime:    time.Unix(0, track.FirstUnixNanos).Format(time.RFC3339),
-			EndTime:      time.Unix(0, track.LastUnixNanos).Format(time.RFC3339),
-			DurationSecs: float64(track.LastUnixNanos-track.FirstUnixNanos) / 1e9,
+			StartTime:    time.Unix(0, track.StartUnixNanos).Format(time.RFC3339),
+			EndTime:      time.Unix(0, track.EndUnixNanos).Format(time.RFC3339),
+			DurationSecs: float64(track.EndUnixNanos-track.StartUnixNanos) / 1e9,
 			Observations: track.ObservationCount,
 			AvgSpeedMps:  track.AvgSpeedMps,
 			MaxSpeedMps:  track.MaxSpeedMps,

--- a/image/Dockerfile.build
+++ b/image/Dockerfile.build
@@ -9,7 +9,7 @@
 #   docker build -f image/Dockerfile.build -t velocity-builder .
 #   docker run --rm -v $PWD/image/velocity-binaries:/out velocity-builder
 
-FROM golang:1.25-bookworm
+FROM golang:1.26-bookworm
 
 # Install ARM64 cross-compilation toolchain and libpcap headers
 RUN dpkg --add-architecture arm64 && \


### PR DESCRIPTION
# Purpose

This pull request includes several updates to improve code correctness and maintainability, as well as an update to the build environment. The main changes involve correcting field references in the Go code for track analysis and updating the Go version in the Docker build file.

# Changes

**Go code improvements:**

* Replaced usage of the `State` field with `TrackState` in the track confirmation logic in `cmd/tools/pcap-analyse/main.go` to match the correct struct field.
* Changed time-related field references from `FirstUnixNanos`/`LastUnixNanos` to `StartUnixNanos`/`EndUnixNanos` for start/end time and duration calculations, ensuring consistency with the track struct and improving accuracy.

**Build and workflow updates:**

* Updated the Go version from `1.25` to `1.26` in `image/Dockerfile.build` to use the latest supported environment.
* Removed the explicit `version: 10` parameter from the `pnpm/action-setup` step in `.github/workflows/lint-autofix.yml`, likely to use the default or a more flexible versioning strategy.

# Checklist

- [ ] Uses British English spelling/wording where applicable.
- [ ] Design is confirmed and aligns with `DESIGN.md`.
- [ ] Any maths/derived values are valid and up to date.
- [ ] Version has been bumped where required.
- [ ] Documentation is up to date.
- [ ] `README.md` is up to date.
- [ ] `docs/DEVLOG.md` is up to date.
