### PR TITLE
[docs] add opengraph tags to all pages

### DIFF
--- a/public_html/src/_data/site.json
+++ b/public_html/src/_data/site.json
@@ -1,0 +1,8 @@
+{
+  "url": "https://velocity.report",
+  "name": "velocity.report",
+  "description": "Open-source speed monitoring for neighbourhood streets. A Raspberry Pi and a radar sensor become a speed logger and PDF report. No cameras, no licence plates, no cloud.",
+  "og_image": "/img/guide-stack.jpg",
+  "og_image_width": 1200,
+  "og_image_height": 900
+}

--- a/public_html/src/_layouts/base.njk
+++ b/public_html/src/_layouts/base.njk
@@ -1,10 +1,39 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full">
+<html lang="en" class="h-full">{# OpenGraph / Twitter Card metadata #}
+{% set pageTitle = title or site.name %}
+{% set pageDescription = description or site.description %}
+{% set pageImage = og_image or site.og_image %}
+{% set pageImageAbs = (site.url + pageImage) if (pageImage[0] == "/") else pageImage %}
+{% set pageUrl = site.url + page.url %}
+{% set ogType = og_type or ("article" if section else "website") %}
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="color-scheme" content="light dark">
-    <title>{{ title or "Velocity Report" }}</title>
+    <title>{{ pageTitle }}</title>
+    <meta name="description" content="{{ pageDescription }}">
+    <link rel="canonical" href="{{ pageUrl }}">
+
+    {# OpenGraph #}
+    <meta property="og:type" content="{{ ogType }}">
+    <meta property="og:site_name" content="{{ site.name }}">
+    <meta property="og:title" content="{{ pageTitle }}">
+    <meta property="og:description" content="{{ pageDescription }}">
+    <meta property="og:url" content="{{ pageUrl }}">
+    <meta property="og:image" content="{{ pageImageAbs }}">
+    {% if (og_image or site.og_image) == site.og_image %}
+    <meta property="og:image:width" content="{{ site.og_image_width }}">
+    <meta property="og:image:height" content="{{ site.og_image_height }}">
+    {% endif %}
+    <meta property="og:locale" content="en_US">
+
+    {# Twitter Card #}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ pageTitle }}">
+    <meta name="twitter:description" content="{{ pageDescription }}">
+    <meta name="twitter:image" content="{{ pageImageAbs }}">
+    {% if site.twitter %}<meta name="twitter:site" content="{{ site.twitter }}">{% endif %}
+
     <link rel="icon" href="/img/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">

--- a/public_html/src/community/index.md
+++ b/public_html/src/community/index.md
@@ -1,6 +1,7 @@
 ---
 layout: page.njk
-title: Community
+title: "Community — velocity.report"
+description: "Discord and GitHub for velocity.report users and contributors. Chat, support, bug reports, and feature requests."
 eleventyExcludeFromCollections: true
 ---
 

--- a/public_html/src/community/index.md
+++ b/public_html/src/community/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page.njk
-title: "Community — velocity.report"
+title: "Community: velocity.report"
 description: "Discord and GitHub for velocity.report users and contributors. Chat, support, bug reports, and feature requests."
 eleventyExcludeFromCollections: true
 ---

--- a/public_html/src/guides/index.md
+++ b/public_html/src/guides/index.md
@@ -1,6 +1,7 @@
 ---
 layout: page.njk
-title: Guides
+title: "Guides — velocity.report"
+description: "How-to guides for building and running a velocity.report sensor: hardware, setup, and producing PDF reports from your data."
 eleventyExcludeFromCollections: true
 ---
 

--- a/public_html/src/guides/index.md
+++ b/public_html/src/guides/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page.njk
-title: "Guides — velocity.report"
+title: "Guides: velocity.report"
 description: "How-to guides for building and running a velocity.report sensor: hardware, setup, and producing PDF reports from your data."
 eleventyExcludeFromCollections: true
 ---

--- a/public_html/src/guides/setup.md
+++ b/public_html/src/guides/setup.md
@@ -8,6 +8,7 @@ time: 2-4 hours
 cost: $650
 date: 2026-04-15T12:00:00Z
 tags: [hardware, raspberry-pi, infrastructure, traffic-safety]
+og_image: /img/guide-hero.jpg
 ---
 
 **A weatherproof traffic logger that keeps data local, requires no cameras, and helps you make a data-informed case for safer streets.**

--- a/public_html/src/index.njk
+++ b/public_html/src/index.njk
@@ -1,6 +1,8 @@
 ---
 layout: page.njk
 title: "velocity.report: Measure Traffic Speeds, Demand Safer Streets"
+description: "Free, open-source software that turns a Raspberry Pi and a radar sensor into a speed monitor. Point it at your street and get a PDF you can take to City Hall. No cameras, no licence plates, no cloud."
+og_image: /img/stack.png
 ---
 
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-gray-900 dark:text-gray-100">

--- a/public_html/src/tool/protractor/index.njk
+++ b/public_html/src/tool/protractor/index.njk
@@ -1,7 +1,8 @@
 ---
 layout: page.njk
-title: Protractor
+title: "Protractor — velocity.report"
 description: Turn a top-down radar photo into the cosine error angle used to correct measured speeds.
+og_image: /img/guide-cosign-angle.jpg
 ---
 
 <section class="max-w-6xl mx-auto">

--- a/public_html/src/tool/protractor/index.njk
+++ b/public_html/src/tool/protractor/index.njk
@@ -1,6 +1,6 @@
 ---
 layout: page.njk
-title: "Protractor — velocity.report"
+title: "Protractor: velocity.report"
 description: Turn a top-down radar photo into the cosine error angle used to correct measured speeds.
 og_image: /img/guide-cosign-angle.jpg
 ---


### PR DESCRIPTION
facilitate rich embeds in Discord, Bsky, etc... by adding opengraph metadata tags populated by frontmatter data.

# Purpose

Describe why this change is needed and what problem it solves.

# Changes

- Summarize the key code changes made in this PR.

# Checklist

- [ ] Uses British English spelling/wording where applicable.
- [ ] Design is confirmed and aligns with `DESIGN.md`.
- [ ] Any maths/derived values are valid and up to date.
- [ ] Version has been bumped where required.
- [ ] Documentation is up to date.
- [ ] `README.md` is up to date.
- [ ] `docs/DEVLOG.md` is up to date.
