### PR TITLE
[ci] fix macOS + uuid

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - "tools/visualiser-macos/**"
       - "proto/velocity_visualiser/**"
-      - ".github/workflows/mac-ci.yml"
 
   # Tags and manual dispatch produce a versioned DMG artefact.
   push:

--- a/docs_html/package.json
+++ b/docs_html/package.json
@@ -17,5 +17,10 @@
     "markdown-it-anchor": "^9.2.0",
     "markdown-it-texmath": "^1.0.0",
     "mermaid": "^11.12.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "uuid": "^11.1.1"
+    }
   }
 }

--- a/docs_html/pnpm-lock.yaml
+++ b/docs_html/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  uuid: ^11.1.1
+
 importers:
 
   .:
@@ -1014,8 +1017,8 @@ packages:
   urlpattern-polyfill@10.1.0:
     resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vscode-jsonrpc@8.2.0:
@@ -1936,7 +1939,7 @@ snapshots:
       roughjs: 4.6.6
       stylis: 4.4.0
       ts-dedent: 2.2.0
-      uuid: 11.1.0
+      uuid: 11.1.1
 
   mime-db@1.54.0: {}
 
@@ -2145,7 +2148,7 @@ snapshots:
 
   urlpattern-polyfill@10.1.0: {}
 
-  uuid@11.1.0: {}
+  uuid@11.1.1: {}
 
   vscode-jsonrpc@8.2.0: {}
 


### PR DESCRIPTION
# Purpose

This pull request updates the `uuid` dependency to version 11.1.1 in the `docs_html` package and ensures the correct version is enforced via pnpm overrides. It also removes an unnecessary workflow path trigger from the macOS CI configuration.

# Changes

Dependency updates:

* Updated `uuid` to version 11.1.1 in `docs_html/pnpm-lock.yaml` and its dependency snapshots to ensure the latest patch is used. [[1]](diffhunk://#diff-cebdd59614c9b67e268129f5cf773d87bd3bb4eedbd86755ec8f4fa03f690e63L1017-R1021) [[2]](diffhunk://#diff-cebdd59614c9b67e268129f5cf773d87bd3bb4eedbd86755ec8f4fa03f690e63L1939-R1942) [[3]](diffhunk://#diff-cebdd59614c9b67e268129f5cf773d87bd3bb4eedbd86755ec8f4fa03f690e63L2148-R2151)
* Added a pnpm override for `uuid` version 11.1.1 in both `docs_html/package.json` and `docs_html/pnpm-lock.yaml` to enforce consistency across all dependencies. [[1]](diffhunk://#diff-0cd019d21103541899fa4785a1a6a3f4b94268d87ad696e1ac2a85caf420a795R20-R24) [[2]](diffhunk://#diff-cebdd59614c9b67e268129f5cf773d87bd3bb4eedbd86755ec8f4fa03f690e63R7-R9)

CI configuration:

* Removed `.github/workflows/mac-ci.yml` from the workflow path triggers to prevent unnecessary workflow runs on changes to the workflow file itself.

# Checklist

- [ ] Uses British English spelling/wording where applicable.
- [ ] Design is confirmed and aligns with `DESIGN.md`.
- [ ] Any maths/derived values are valid and up to date.
- [ ] Version has been bumped where required.
- [ ] Documentation is up to date.
- [ ] `README.md` is up to date.
- [ ] `docs/DEVLOG.md` is up to date.
