### PR TITLE
[go] allow opt-in Tailscale ACLs for admin/view access

### DIFF
--- a/docs/platform/operations/tailscale-remote-access.md
+++ b/docs/platform/operations/tailscale-remote-access.md
@@ -1,203 +1,231 @@
 # Tailscale remote access
 
-Tailscale creates a WireGuard mesh VPN that gives every enrolled device a
-stable `100.x.y.z` address: no port forwarding, no dynamic DNS, no exposure
-to public internet scanners. This guide covers RPi-specific installation,
-recommended `tailscale up` flags, ACL policy for a velocity-report deployment,
-and SSH access.
+Operator and contributor reference for the Tailscale integration on the
+Pi image. For the click-through enrolment flow that an end user sees,
+read the user guide at
+[public_html/src/guides/tailscale.md](../../../public_html/src/guides/tailscale.md)
+instead.
 
-## Scope
+## What's vendored
 
-RPi only. The [setup guide](../../../public_html/src/guides/setup.md#remote-access-with-tailscale-optional)
-covers the 5-minute quickstart; this document goes deeper with production
-flags, access control, and integration with the server's existing
-[listener architecture](../../radar/architecture/networking.md).
+The Pi image installs `tailscaled` and the `tailscale` CLI from the
+upstream apt repo, then **masks** the systemd unit. Nothing reaches
+out to Tailscale's coordination server unless the operator opts in
+through the web UI. This is a privacy tenet, not a configuration
+detail: the image is published publicly and may run in environments
+where outbound traffic is sensitive, so the default state is
+"installed but inert."
 
-## 1. Install Tailscale on the Raspberry Pi
+| Concern             | Where it lives                                                                        |
+| ------------------- | ------------------------------------------------------------------------------------- |
+| Package install     | [image/stage-velocity/07-velocity-tailscale/01-run.sh](../../../image/stage-velocity/07-velocity-tailscale/01-run.sh) |
+| systemd unmask flow | [cmd/velocity-ctl/tailscale.go](../../../cmd/velocity-ctl/tailscale.go)               |
+| sudoers grant       | [image/stage-velocity/03-velocity-config/00-run.sh](../../../image/stage-velocity/03-velocity-config/00-run.sh) (lines 49–51) |
+| Manager / IPN bus   | [internal/tailscale/manager.go](../../../internal/tailscale/manager.go)               |
+| HTTP endpoints      | [internal/api/server_tailscale.go](../../../internal/api/server_tailscale.go)         |
+| Web UI              | [web/src/routes/(constrained)/settings/+page.svelte](../../../web/src/routes/%28constrained%29/settings/+page.svelte) |
 
-```bash
-curl -fsSL https://tailscale.com/install.sh | sh
+## Trust model
+
+Three boundaries, each enforced by something other than convention:
+
+1. **Daemon lifecycle requires root** (unmask/enable/start/stop/mask).
+   The non-root `velocity` service user is granted exactly two sudo
+   actions, by literal argv with no wildcards:
+
+   ```
+   /usr/local/bin/velocity-ctl tailscale enable-tailscaled
+   /usr/local/bin/velocity-ctl tailscale disable-tailscaled
+   ```
+
+2. **Daemon configuration runs as `velocity`** over the local API
+   socket. After the daemon starts, `velocity-ctl` runs
+   `tailscale set --operator=velocity`, which authorises the service
+   user to drive `tailscaled` without root for everything else
+   (login, prefs, serve config, status).
+
+3. **Inbound HTTP authorization is by source plus optional
+   capability grant.** LAN and loopback are admin; the tailnet is
+   gated by `velocity.report/cap/{view,admin}` grants in your tailnet
+   policy (see [Capability grants](#capability-grants) below).
+
+## Enable / disable flow
+
+When the operator toggles Tailscale on in Settings:
+
+1. The web UI POSTs `/api/tailscale/enable`. The Go server shells
+   out to `sudo /usr/local/bin/velocity-ctl tailscale
+   enable-tailscaled`, which unmasks, enables, and starts the
+   service, waits up to 15 s for `/var/run/tailscale/tailscaled.sock`
+   to appear, and runs `tailscale set --operator=velocity`.
+2. The manager subscribes to the IPN bus, calls
+   `StartLoginInteractive`, and caches the resulting `BrowseToURL`
+   for up to 5 minutes.
+3. The web UI fast-polls `/api/tailscale/status` (every 2 s during
+   login) and renders the URL plus a QR code. The user opens it in
+   their tailnet account and approves the device.
+4. Once the node reaches `Running`, `applyDevicePolicy` runs **once
+   per Enable**:
+   - `RunSSH=true` via `EditPrefs` → Tailscale SSH on.
+   - `SetServeConfig` with a web handler at `https://<fqdn>:443/`
+     proxying to `http://127.0.0.1:8080` → web UI on the tailnet.
+
+   These two steps record their results independently
+   (`sshOK`/`sshErr`, `serveOK`/`serveErr`) so the Settings page can
+   surface partial failures.
+
+Disable reverses it: clear the serve config, set `WantRunning=false`,
+then `disable-tailscaled` runs `stop`, `disable`, and `mask` in that
+order. The node identity stays on disk; toggling on again resumes
+the same membership without a fresh login.
+
+## What the operator still has to do
+
+The image vendors the daemon and the lifecycle plumbing. It does
+**not** vendor anything that has to live in your tailnet account:
+
+- A Tailscale account and tailnet (free personal plan is fine).
+- HTTPS certificates enabled at
+  [login.tailscale.com/admin/dns](https://login.tailscale.com/admin/dns),
+  if you want the served web UI to be `https://`. The device
+  fetches its certificate automatically on first connect.
+- Optional but recommended: a `tag:velocity-report` tag and ACL
+  rules. The default tailnet policy lets every member reach every
+  member, which is fine for a single-user setup but coarse for
+  shared tailnets.
+- Optional: `velocity.report/cap/*` grants if you want to split read
+  from write access across users.
+
+There is no headless / auth-key path in the web UI. The flow is
+always interactive login. If you need headless enrolment for fleet
+deployment, run `sudo tailscale up --auth-key=…` on the Pi over SSH
+*before* using the web UI; the manager picks up the running daemon
+on its first poll.
+
+## Capability grants
+
+By default any tailnet peer that can reach the Pi has full admin
+access. To split read from write, use
+[application capability grants](https://tailscale.com/kb/1324/grants-app-capabilities).
+
+velocity-report recognises two cap names:
+
+- `velocity.report/cap/view` — read-only access to `/api/*` and
+  `/events`.
+- `velocity.report/cap/admin` — full access (implies view).
+
+Add a grant to your tailnet policy:
+
+```hujson
+"grants": [
+  {
+    "src": ["autogroup:member"],
+    "dst": ["tag:velocity-report"],
+    "app": { "velocity.report/cap/view": [{}] }
+  },
+  {
+    "src": ["group:operators"],
+    "dst": ["tag:velocity-report"],
+    "app": { "velocity.report/cap/admin": [{}] }
+  }
+]
 ```
 
-This installs the `tailscaled` daemon and the `tailscale` CLI. On
-Raspberry Pi OS (Debian-based), the installer adds the apt repository and
-starts the service automatically.
+### Enforcement modes
 
-Verify:
+The `-ts-cap-enforcement` flag on `velocity-report` controls whether
+the gate is active:
 
-```bash
-tailscale version
-systemctl status tailscaled
-```
+| Mode  | Behaviour                                                                                                          |
+| ----- | ------------------------------------------------------------------------------------------------------------------ |
+| `off` | (default) Capability checks disabled. Every reachable peer is admin. Use this until grants are validated.          |
+| `on`  | Enforce caps for tailnet-sourced requests. LAN and loopback are still admin. Flip to `on` after grants are wired.  |
 
-## 2. Authenticate and bring the node up
+### Trust model
 
-### Minimal (interactive)
+The gate is a **default-deny wrapper** installed around the entire HTTP
+mux. Anything not on a small explicit allowlist requires a cap; routes
+added later by other packages (LiDAR, debug, db admin, etc.) inherit
+the default-deny policy automatically.
 
-```bash
-sudo tailscale up
-```
+Source classification rules:
 
-Follow the printed URL to authenticate in a browser. Suitable for a Pi
-with a keyboard/monitor attached, or when SSH'd in.
+- **Loopback `RemoteAddr` + `X-Forwarded-For` set** → trust XFF; this
+  is how `tailscale serve` forwards tailnet requests to the local
+  HTTP server.
+- **Loopback with no XFF** → host-local (the Go server itself,
+  `velocity-ctl`, a local `curl`). Treated as admin.
+- **Non-loopback `RemoteAddr`** → LAN or direct hit on `:8080`.
+  `X-Forwarded-For` is **ignored** entirely so a LAN attacker who
+  can reach the server directly cannot forge a tailnet identity by
+  setting the header. Treated as admin.
 
-### Headless (recommended for RPi)
+Failure modes:
 
-Generate an auth key from the
-[Tailscale admin console](https://login.tailscale.com/admin/settings/keys):
+- The daemon authoritatively reporting "no such peer" → 403
+  `{"error":"unknown_peer"}`.
+- A transient lookup error (socket down, timeout) → fail-open. A
+  tailscaled blip should not deny every authorised user at once.
+- A peer with no caps → 403 `{"error":"missing_cap","required":"…"}`.
 
-- **Reusable:** No (single-use is safer for a fixed device)
-- **Ephemeral:** No (the Pi is a permanent node)
-- **Pre-approved:** Yes (avoids manual approval)
-- **Tags:** `tag:velocity-report` (see ACL section below)
+### Caveats
 
-```bash
-sudo tailscale up --auth-key=tskey-auth-<key> --hostname=velocity-pi
-```
+- **Non-tailnet sources are always admin.** Loopback (`127.0.0.1`,
+  `velocity-ctl`) and LAN sources bypass the cap check entirely.
+  Gate LAN access at the network layer (firewall, VLAN) if that
+  isn't acceptable.
+- **`/api/tailscale/status` is unconditionally reachable** so an
+  operator with a botched grant policy can still see the daemon
+  state and recover.
+- **Grants only protect the velocity-report HTTP API.** They do not
+  cover Tailscale SSH, the gRPC visualiser stream, or any other
+  port. Use ACL rules for those.
+- **Recovery from a misconfigured ACL relies on the LAN bypass.**
+  Once you've validated grants on a test peer, flip
+  `-ts-cap-enforcement=on` and restart.
 
-### Recommended flags
+## Hostname and MagicDNS
 
-| Flag                      | Purpose                                                       |
-| ------------------------- | ------------------------------------------------------------- |
-| `--hostname=velocity-pi`  | Human-readable MagicDNS name (`velocity-pi.<tailnet>.ts.net`) |
-| `--auth-key=tskey-auth-…` | Headless authentication: no browser needed                    |
-| `--ssh`                   | Enable Tailscale SSH (see §5 below)                           |
-| `--accept-dns=true`       | Accept MagicDNS names (default; listed for clarity)           |
+The MagicDNS name comes from the daemon, not from the image. The
+daemon picks up the system hostname at first `tailscale up`, then
+the coordination server owns it. To set a specific hostname, run
+`sudo tailscale up --hostname=<name>` on the Pi over SSH before
+toggling on in the web UI; once enrolled, the name is sticky.
+The web UI displays the FQDN and short name on the Settings page
+when connected.
 
-Full command for production:
+## Listener layout
 
-```bash
-sudo tailscale up \
-  --auth-key=tskey-auth-<key> \
-  --hostname=velocity-pi \
-  --ssh
-```
+The served web UI proxies to `http://127.0.0.1:8080` — the same Go
+server that the LAN reaches. The LiDAR monitor on `:8081` is **not**
+proxied through tailscale serve and is reachable over the tailnet
+only via its IP (`http://<tailnet-ip>:8081`). See
+[networking.md](../../radar/architecture/networking.md) for the
+full listener segmentation.
 
-## 3. Access the velocity-report web UI
+## Troubleshooting
 
-Once Tailscale is running on both the Pi and a phone/laptop:
+| Symptom                                         | Likely cause                                                                                  | Where to look                                                                                                                  |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Toggle errors with "operation not permitted"    | sudoers entry missing or the `velocity` user is not in the `velocity` group.                  | Re-image, or apply [03-velocity-config/00-run.sh](../../../image/stage-velocity/03-velocity-config/00-run.sh) by hand.         |
+| Login URL never appears                         | Daemon cannot reach `login.tailscale.com`. Almost always a DNS or outbound-firewall problem.  | `journalctl -u tailscaled` and `tailscale netcheck` over SSH.                                                                  |
+| Connected but Settings shows "Web UI: failed"   | MagicDNS name not yet propagated, or HTTPS certs disabled in the admin console.               | The manager retries serve setup 6 times; if it still fails, enable HTTPS at `login.tailscale.com/admin/dns` and toggle off/on. |
+| Cap-gated peer gets 403 when it shouldn't       | Grant is on the wrong tailnet policy line, or `-ts-cap-enforcement=on` was set prematurely.   | Check the grant in the admin console, and look for `auth: capability enforcement armed` in the journald log.                   |
+| LAN client unexpectedly hits 403                | The LAN bypass relies on the request not coming through tailscale serve. Funnel breaks this.  | Funnel is unsupported (see Non-goals). If you've enabled it, disable it.                                                       |
 
-```text
-http://velocity-pi             # web UI on :80 (MagicDNS, if enabled)
-http://100.x.y.z               # web UI on :80 (Tailscale IP, always works)
-```
-
-The LiDAR monitor is on `:8081`:
-
-```text
-http://velocity-pi:8081
-```
-
-Tailscale-protected debug endpoints (serial commands, DB backup, tailsql,
-pprof) are served on `:80` under `/debug/*` via `tsweb.Debugger`: these
-are accessible only from loopback or authenticated Tailscale peers. See
-[networking.md](../../radar/architecture/networking.md) for the full listener
-segmentation.
-
-## 4. ACL policy recommendations
-
-Tailscale ACLs live in the
-[admin console](https://login.tailscale.com/admin/acls/file). Below is a
-minimal policy for a velocity-report deployment.
-
-### Tags
-
-Set `tag:velocity-report` ownership to `autogroup:admin` in the `tagOwners` section.
-
-### ACL rules
-
-Add two rules to the `acls` array:
-
-| Rule | Action   | Source                | Destination             | Purpose                                                                  |
-| ---- | -------- | --------------------- | ----------------------- | ------------------------------------------------------------------------ |
-| 1    | `accept` | `autogroup:member`    | `tag:velocity-report:*` | Allow all Tailscale members to reach the Pi on all ports                 |
-| 2    | `accept` | `tag:velocity-report` | `tag:velocity-report:*` | Allow the Pi to reach only other velocity-report nodes (least privilege) |
-
-This grants all Tailscale members access to the Pi's web UI, SSH, and
-debug endpoints. The Pi itself can only talk to other velocity-report
-nodes (useful if you add a second Pi).
-
-### Restricting port access
-
-For tighter control, replace `*` with specific ports: set the destination
-to `tag:velocity-report:80,8081,22` to restrict access to the web UI
-(80), LiDAR monitor (8081), and SSH (22) only.
-
-## 5. SSH access via Tailscale
-
-With `--ssh` enabled at bring-up, Tailscale provides SSH access without
-managing host keys or opening port 22 on the LAN:
-
-```bash
-ssh velocity-pi              # MagicDNS
-ssh 100.x.y.z               # Tailscale IP
-```
-
-Tailscale SSH authenticates via the Tailscale identity, not SSH keys. The
-SSH ACL in the admin console controls who can connect. Add a rule to the
-`ssh` array:
-
-| Key      | Value                 | Purpose                |
-| -------- | --------------------- | ---------------------- |
-| `action` | `accept`              | Allow SSH connections  |
-| `src`    | `autogroup:member`    | All Tailscale members  |
-| `dst`    | `tag:velocity-report` | The velocity-report Pi |
-| `users`  | `pi`, `root`          | Permitted login users  |
-
-**Benefit:** No need to distribute SSH keys or manage `authorized_keys`.
-Revoking a team member's Tailscale access immediately revokes their SSH
-access.
-
-## 6. Verifying the setup
-
-From any enrolled device:
-
-```bash
-# Check the Pi is reachable
-tailscale ping velocity-pi
-
-# Verify the web UI
-curl -s http://velocity-pi/api/config | head -c 200
-
-# Verify debug endpoints (Tailscale peers only)
-curl -s http://velocity-pi/debug/db-stats
-```
-
-From the Pi itself:
-
-```bash
-tailscale status          # List connected peers
-tailscale netcheck        # Diagnose connectivity
-```
-
-## 7. Keeping Tailscale updated
-
-Tailscale updates itself via apt on Debian-based systems:
-
-```bash
-sudo apt update && sudo apt upgrade tailscale
-```
-
-Or enable auto-update:
-
-```bash
-sudo tailscale set --auto-update
-```
-
-## 8. Troubleshooting
-
-| Symptom                      | Cause                              | Fix                                        |
-| ---------------------------- | ---------------------------------- | ------------------------------------------ |
-| `tailscale up` hangs         | Pi has no internet access          | Check `eth0`/`wlan0` gateway and DNS       |
-| MagicDNS names don't resolve | MagicDNS disabled in admin console | Enable under DNS settings in admin console |
-| `/debug/*` returns 403       | Request not from Tailscale peer    | Access via Tailscale IP, not LAN IP        |
-| SSH connection refused       | `--ssh` not passed at bring-up     | `sudo tailscale set --ssh`                 |
+For the velocity-report side, `journalctl -u velocity-report` shows
+all auth-gate decisions (the arming event, WhoIs failures, and any
+403 responses).
 
 ## Non-goals
 
-- **Tailscale on macOS visualiser**: covered separately if needed; the
-  visualiser connects to the Pi's gRPC endpoint, which is reachable over
-  Tailscale without additional configuration.
-- **Tailscale Funnel**: exposes services to the public internet; directly
-  conflicts with the privacy-first deployment model.
-- **Multi-site mesh**: coordinating multiple Pis is a future concern.
+- **Tailscale Funnel** (public-internet exposure). Conflicts with
+  the privacy tenet and breaks the LAN-vs-tailnet source
+  classification that capability grants depend on.
+- **Multi-site mesh.** Coordinating multiple Pis on one tailnet
+  works fine, but aggregating their data is a separate project.
+- **Headless auth-key via the web UI.** Available via the CLI on
+  the Pi; deliberately not surfaced in the toggle.
+- **Tailscale on the macOS visualiser.** The visualiser reaches the
+  gRPC endpoint over the tailnet without further configuration once
+  both ends are enrolled.

--- a/docs/platform/operations/tailscale-remote-access.md
+++ b/docs/platform/operations/tailscale-remote-access.md
@@ -16,14 +16,14 @@ detail: the image is published publicly and may run in environments
 where outbound traffic is sensitive, so the default state is
 "installed but inert."
 
-| Concern             | Where it lives                                                                        |
-| ------------------- | ------------------------------------------------------------------------------------- |
-| Package install     | [image/stage-velocity/07-velocity-tailscale/01-run.sh](../../../image/stage-velocity/07-velocity-tailscale/01-run.sh) |
-| systemd unmask flow | [cmd/velocity-ctl/tailscale.go](../../../cmd/velocity-ctl/tailscale.go)               |
+| Concern             | Where it lives                                                                                                                |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Package install     | [image/stage-velocity/07-velocity-tailscale/01-run.sh](../../../image/stage-velocity/07-velocity-tailscale/01-run.sh)         |
+| systemd unmask flow | [internal/cmd/device/tailscale.go](../../../internal/cmd/device/tailscale.go)                                                 |
 | sudoers grant       | [image/stage-velocity/03-velocity-config/00-run.sh](../../../image/stage-velocity/03-velocity-config/00-run.sh) (lines 49–51) |
-| Manager / IPN bus   | [internal/tailscale/manager.go](../../../internal/tailscale/manager.go)               |
-| HTTP endpoints      | [internal/api/server_tailscale.go](../../../internal/api/server_tailscale.go)         |
-| Web UI              | [web/src/routes/(constrained)/settings/+page.svelte](../../../web/src/routes/%28constrained%29/settings/+page.svelte) |
+| Manager / IPN bus   | [internal/tailscale/manager.go](../../../internal/tailscale/manager.go)                                                       |
+| HTTP endpoints      | [internal/api/server_tailscale.go](../../../internal/api/server_tailscale.go)                                                 |
+| Web UI              | [web/src/routes/settings/+page.svelte](../../../web/src/routes/settings/+page.svelte)                                         |
 
 ## Trust model
 
@@ -55,7 +55,7 @@ When the operator toggles Tailscale on in Settings:
 
 1. The web UI POSTs `/api/tailscale/enable`. The Go server shells
    out to `sudo /usr/local/bin/velocity-ctl tailscale
-   enable-tailscaled`, which unmasks, enables, and starts the
+enable-tailscaled`, which unmasks, enables, and starts the
    service, waits up to 15 s for `/var/run/tailscale/tailscaled.sock`
    to appear, and runs `tailscale set --operator=velocity`.
 2. The manager subscribes to the IPN bus, calls
@@ -99,7 +99,7 @@ The image vendors the daemon and the lifecycle plumbing. It does
 There is no headless / auth-key path in the web UI. The flow is
 always interactive login. If you need headless enrolment for fleet
 deployment, run `sudo tailscale up --auth-key=…` on the Pi over SSH
-*before* using the web UI; the manager picks up the running daemon
+_before_ using the web UI; the manager picks up the running daemon
 on its first poll.
 
 ## Capability grants
@@ -136,10 +136,10 @@ Add a grant to your tailnet policy:
 The `-ts-cap-enforcement` flag on `velocity-report` controls whether
 the gate is active:
 
-| Mode  | Behaviour                                                                                                          |
-| ----- | ------------------------------------------------------------------------------------------------------------------ |
-| `off` | (default) Capability checks disabled. Every reachable peer is admin. Use this until grants are validated.          |
-| `on`  | Enforce caps for tailnet-sourced requests. LAN and loopback are still admin. Flip to `on` after grants are wired.  |
+| Mode  | Behaviour                                                                                                         |
+| ----- | ----------------------------------------------------------------------------------------------------------------- |
+| `off` | (default) Capability checks disabled. Every reachable peer is admin. Use this until grants are validated.         |
+| `on`  | Enforce caps for tailnet-sourced requests. LAN and loopback are still admin. Flip to `on` after grants are wired. |
 
 ### Trust model
 
@@ -205,13 +205,13 @@ full listener segmentation.
 
 ## Troubleshooting
 
-| Symptom                                         | Likely cause                                                                                  | Where to look                                                                                                                  |
-| ----------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| Toggle errors with "operation not permitted"    | sudoers entry missing or the `velocity` user is not in the `velocity` group.                  | Re-image, or apply [03-velocity-config/00-run.sh](../../../image/stage-velocity/03-velocity-config/00-run.sh) by hand.         |
-| Login URL never appears                         | Daemon cannot reach `login.tailscale.com`. Almost always a DNS or outbound-firewall problem.  | `journalctl -u tailscaled` and `tailscale netcheck` over SSH.                                                                  |
-| Connected but Settings shows "Web UI: failed"   | MagicDNS name not yet propagated, or HTTPS certs disabled in the admin console.               | The manager retries serve setup 6 times; if it still fails, enable HTTPS at `login.tailscale.com/admin/dns` and toggle off/on. |
-| Cap-gated peer gets 403 when it shouldn't       | Grant is on the wrong tailnet policy line, or `-ts-cap-enforcement=on` was set prematurely.   | Check the grant in the admin console, and look for `auth: capability enforcement armed` in the journald log.                   |
-| LAN client unexpectedly hits 403                | The LAN bypass relies on the request not coming through tailscale serve. Funnel breaks this.  | Funnel is unsupported (see Non-goals). If you've enabled it, disable it.                                                       |
+| Symptom                                       | Likely cause                                                                                 | Where to look                                                                                                                  |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Toggle errors with "operation not permitted"  | sudoers entry missing or the `velocity` user is not in the `velocity` group.                 | Re-image, or apply [03-velocity-config/00-run.sh](../../../image/stage-velocity/03-velocity-config/00-run.sh) by hand.         |
+| Login URL never appears                       | Daemon cannot reach `login.tailscale.com`. Almost always a DNS or outbound-firewall problem. | `journalctl -u tailscaled` and `tailscale netcheck` over SSH.                                                                  |
+| Connected but Settings shows "Web UI: failed" | MagicDNS name not yet propagated, or HTTPS certs disabled in the admin console.              | The manager retries serve setup 6 times; if it still fails, enable HTTPS at `login.tailscale.com/admin/dns` and toggle off/on. |
+| Cap-gated peer gets 403 when it shouldn't     | Grant is on the wrong tailnet policy line, or `-ts-cap-enforcement=on` was set prematurely.  | Check the grant in the admin console, and look for `auth: capability enforcement armed` in the journald log.                   |
+| LAN client unexpectedly hits 403              | The LAN bypass relies on the request not coming through tailscale serve. Funnel breaks this. | Funnel is unsupported (see Non-goals). If you've enabled it, disable it.                                                       |
 
 For the velocity-report side, `journalctl -u velocity-report` shows
 all auth-gate decisions (the arming event, WhoIs failures, and any

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,0 +1,308 @@
+// Capability-grant authorization for the HTTP API.
+//
+// Tailscale application capability grants
+// (https://tailscale.com/kb/1324/grants-app-capabilities) are used
+// to split the API surface between read-only and admin clients.
+// The middleware is applied to the entire mux at Start() time with
+// a small allowlist of unauthenticated paths, so adding a new route
+// later does not silently bypass the gate.  See server.go for the
+// allowlist and how the wrapper is composed.
+//
+// Trust model
+//
+// 1. Source classification.  A request is "from the tailnet" only
+//    when it actually arrived through tailscale serve, which means
+//    the upstream connection lands on loopback and the original
+//    peer IP is in X-Forwarded-For.  Anywhere else (LAN, direct hit
+//    on :8080, host-network requests from velocity-ctl) is treated
+//    as admin: those paths require already being on a network the
+//    operator controls, which is the same trust boundary the device
+//    has had since it shipped.
+//
+//    XFF is *only* trusted when r.RemoteAddr is loopback, otherwise
+//    a LAN attacker who can reach :8080 directly could forge a
+//    tailnet identity.
+//
+// 2. Authorization on the tailnet.  Once classified as tailnet, the
+//    daemon is asked for the peer's grants via the local API.  Any
+//    one of velocity.report/cap/{view,admin} authorises the
+//    corresponding access level; admin implies view.
+//
+// 3. Failure modes.  A definitive "no such peer" from the daemon
+//    is fail-closed (the tailnet identity is unknown — no caps).
+//    A transient lookup error (socket down, timeout) is fail-open
+//    so that a tailscaled hiccup does not lock every authorised
+//    user out simultaneously.  A daemon outage is logged at every
+//    failure for diagnostic purposes.
+//
+// 4. Modes.  Off disables the entire mechanism — tailnet peers
+//    behave like LAN peers (admin).  On enforces caps for tailnet
+//    peers.  Lockout safety is handled by the LAN bypass: an
+//    operator with a misconfigured ACL drops back to LAN access,
+//    fixes the grants, and tries again.  Operators should leave
+//    the gate off until they have confirmed grants on a test peer.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+	"time"
+
+	"github.com/banshee-data/velocity.report/internal/tailscale"
+)
+
+// CapEnforcement selects whether the auth middleware enforces
+// capability grants for tailnet-sourced requests.
+type CapEnforcement int
+
+const (
+	// EnforcementOff disables capability checks entirely; every
+	// request is treated as admin.  This is the default for
+	// existing deployments that have not configured grants.
+	EnforcementOff CapEnforcement = iota
+	// EnforcementOn enforces capability checks for tailnet-sourced
+	// requests.  LAN/loopback requests still pass as admin.
+	EnforcementOn
+)
+
+// ParseEnforcement maps "off"/"on" (and a few common synonyms) to
+// a CapEnforcement value.  Empty string is treated as "off" for
+// backwards compatibility with deployments that had no flag.
+func ParseEnforcement(s string) (CapEnforcement, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "off", "false", "0", "no":
+		return EnforcementOff, nil
+	case "on", "true", "1", "yes":
+		return EnforcementOn, nil
+	}
+	return EnforcementOff, errors.New("invalid cap enforcement (want off|on)")
+}
+
+// CapKind is the access level a route requires.
+type CapKind int
+
+const (
+	// CapView is sufficient for read-only endpoints.  Holders of
+	// CapAdmin implicitly satisfy CapView.
+	CapView CapKind = iota
+	// CapAdmin is required for any state-mutating endpoint.  Used
+	// as the default for routes that do not opt in explicitly.
+	CapAdmin
+)
+
+// PeerAuthClient is the slice of the Tailscale manager that the
+// auth middleware depends on.  Defined here so tests can substitute
+// a stub without standing up a real tailscale.Manager.
+type PeerAuthClient interface {
+	// LookupPeer resolves a remote address to a PeerIdentity.
+	// Returns tailscale.ErrPeerNotFound when the daemon is
+	// authoritative that the address is not a tailnet peer; any
+	// other error is treated as transient.
+	LookupPeer(ctx context.Context, remoteAddr string) (tailscale.PeerIdentity, error)
+	// LocalTailnetPrefixes returns the tailnet IPs assigned to this
+	// node, used as a belt-and-braces fallback when the CGNAT-range
+	// shortcut does not match (e.g. custom CGNAT ranges).  May
+	// return nil when the daemon is unreachable.
+	LocalTailnetPrefixes(ctx context.Context) []netip.Prefix
+}
+
+// authGate carries the per-server configuration for the middleware.
+// It is stateless beyond the configuration: there is no "armed"
+// flag, no run-time mode flip — restart is the only way to change
+// modes, which keeps the behaviour easy to reason about in incident
+// response.
+type authGate struct {
+	tc      PeerAuthClient
+	mode    CapEnforcement
+	timeout time.Duration
+}
+
+// newAuthGate constructs an authGate.  A nil PeerAuthClient is
+// equivalent to EnforcementOff: every request is admin, no daemon
+// calls are made.
+func newAuthGate(tc PeerAuthClient, mode CapEnforcement) *authGate {
+	if tc == nil {
+		mode = EnforcementOff
+	}
+	return &authGate{tc: tc, mode: mode, timeout: 750 * time.Millisecond}
+}
+
+// requireCap returns middleware that enforces required for any
+// request the gate classifies as tailnet-sourced.  See the package
+// comment for the trust-model semantics.
+func (g *authGate) requireCap(required CapKind, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if g.mode == EnforcementOff || g.tc == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), g.timeout)
+		defer cancel()
+
+		clientIP, fromTailnet := classifySource(r, g, ctx)
+		if !fromTailnet {
+			// LAN/loopback peers retain full access — the LAN
+			// itself is the trust boundary in those deployments.
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		id, err := g.tc.LookupPeer(ctx, clientIP.String())
+		switch {
+		case err == nil:
+			// fall through to grant check
+		case errors.Is(err, tailscale.ErrPeerNotFound):
+			// Authoritative "not a tailnet peer."  We classified
+			// the address as tailnet-sourced, but the daemon
+			// disagrees; fail closed.
+			log.Printf("auth: tailnet-classified IP %s has no tailnet identity", clientIP)
+			writeForbidden(w, "unknown_peer", required)
+			return
+		default:
+			// Transient lookup failure.  Fail open so a tailscaled
+			// blip does not deny every authorised user at once.
+			log.Printf("auth: lookup %s transient error, allowing: %v", clientIP, err)
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		ok := false
+		switch required {
+		case CapView:
+			ok = id.View // PeerIdentity already collapses Admin into View
+		case CapAdmin:
+			ok = id.Admin
+		}
+		if !ok {
+			writeForbidden(w, "missing_cap", required)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// classifySource returns the originating client IP and whether it
+// arrived over the tailnet.  The XFF header is consulted only when
+// r.RemoteAddr is loopback, i.e. the request came from tailscale
+// serve's local proxy.  Anywhere else, only r.RemoteAddr is
+// trusted, which prevents a LAN attacker who can reach :8080
+// directly from forging a tailnet identity by setting XFF.
+func classifySource(r *http.Request, g *authGate, ctx context.Context) (netip.Addr, bool) {
+	remoteIP := remoteAddrIP(r)
+	if !remoteIP.IsValid() {
+		return netip.Addr{}, false
+	}
+	// Trust XFF only when the upstream is loopback (the only path
+	// by which tailscale serve forwards requests to us).
+	if remoteIP.IsLoopback() {
+		if xff := firstXFF(r.Header.Get("X-Forwarded-For")); xff.IsValid() {
+			if isTailnetIP(ctx, g, xff) {
+				return xff, true
+			}
+			// XFF is set but not a tailnet IP: a misconfigured
+			// reverse proxy or a client setting their own header
+			// before us.  Treat as non-tailnet.
+			return xff, false
+		}
+		// Loopback with no XFF: a process on the host (the Go
+		// server itself, velocity-ctl, a local curl).  Non-tailnet,
+		// hence admin.
+		return remoteIP, false
+	}
+	// Direct connection (LAN, or :8080 exposed somewhere).  XFF is
+	// untrusted here.  We still classify by the on-wire source: a
+	// direct connection from a tailnet IP (rare but possible if the
+	// operator explicitly bound the tailnet IP) is treated as
+	// tailnet, but the much more common case is a LAN address.
+	return remoteIP, isTailnetIP(ctx, g, remoteIP)
+}
+
+// firstXFF parses the first entry of an X-Forwarded-For header.
+func firstXFF(xff string) netip.Addr {
+	if xff == "" {
+		return netip.Addr{}
+	}
+	first, _, _ := strings.Cut(xff, ",")
+	ip, err := netip.ParseAddr(strings.TrimSpace(first))
+	if err != nil {
+		return netip.Addr{}
+	}
+	return ip
+}
+
+// remoteAddrIP returns the parsed IP of r.RemoteAddr, or an invalid
+// addr if it cannot be parsed.
+func remoteAddrIP(r *http.Request) netip.Addr {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	if ip, err := netip.ParseAddr(host); err == nil {
+		return ip
+	}
+	return netip.Addr{}
+}
+
+// isTailnetIP reports whether ip is in Tailscale's CGNAT range
+// (the static /10 for IPv4 and /48 for IPv6) or in one of the
+// prefixes the local daemon reports as the node's own (a fallback
+// for unusual deployments).  Cached at the daemon-call layer.
+func isTailnetIP(ctx context.Context, g *authGate, ip netip.Addr) bool {
+	if !ip.IsValid() {
+		return false
+	}
+	if isTailscaleCGNAT(ip) {
+		return true
+	}
+	for _, p := range g.tc.LocalTailnetPrefixes(ctx) {
+		if p.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// Tailscale's CGNAT range is fixed (RFC 6598 100.64/10 carved out
+// for Tailscale, and fd7a:115c:a1e0::/48 for IPv6).
+var (
+	tailscale4 = netip.MustParsePrefix("100.64.0.0/10")
+	tailscale6 = netip.MustParsePrefix("fd7a:115c:a1e0::/48")
+)
+
+func isTailscaleCGNAT(ip netip.Addr) bool {
+	if ip.Is4() || ip.Is4In6() {
+		return tailscale4.Contains(ip.Unmap())
+	}
+	return tailscale6.Contains(ip)
+}
+
+// forbiddenBody is the JSON body returned on 403 so the web UI can
+// distinguish failure modes ("you lack the cap" vs "we couldn't
+// resolve your tailnet identity").  Keep field names stable.
+type forbiddenBody struct {
+	Error    string `json:"error"`
+	Required string `json:"required,omitempty"`
+}
+
+func writeForbidden(w http.ResponseWriter, code string, required CapKind) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	body := forbiddenBody{Error: code}
+	switch required {
+	case CapView:
+		body.Required = "view"
+	case CapAdmin:
+		body.Required = "admin"
+	}
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		log.Printf("auth: encode forbidden body: %v", err)
+	}
+}

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -106,11 +106,6 @@ type PeerAuthClient interface {
 	// authoritative that the address is not a tailnet peer; any
 	// other error is treated as transient.
 	LookupPeer(ctx context.Context, remoteAddr string) (tailscale.PeerIdentity, error)
-	// LocalTailnetPrefixes returns the tailnet IPs assigned to this
-	// node, used as a belt-and-braces fallback when the CGNAT-range
-	// shortcut does not match (e.g. custom CGNAT ranges).  May
-	// return nil when the daemon is unreachable.
-	LocalTailnetPrefixes(ctx context.Context) []netip.Prefix
 }
 
 // authGate carries the per-server configuration for the middleware.
@@ -147,7 +142,7 @@ func (g *authGate) requireCap(required CapKind, next http.Handler) http.Handler 
 		ctx, cancel := context.WithTimeout(r.Context(), g.timeout)
 		defer cancel()
 
-		clientIP, fromTailnet := classifySource(r, g, ctx)
+		clientIP, fromTailnet := classifySource(r)
 		if !fromTailnet {
 			// LAN/loopback peers retain full access — the LAN
 			// itself is the trust boundary in those deployments.
@@ -195,7 +190,7 @@ func (g *authGate) requireCap(required CapKind, next http.Handler) http.Handler 
 // serve's local proxy.  Anywhere else, only r.RemoteAddr is
 // trusted, which prevents a LAN attacker who can reach :8080
 // directly from forging a tailnet identity by setting XFF.
-func classifySource(r *http.Request, g *authGate, ctx context.Context) (netip.Addr, bool) {
+func classifySource(r *http.Request) (netip.Addr, bool) {
 	remoteIP := remoteAddrIP(r)
 	if !remoteIP.IsValid() {
 		return netip.Addr{}, false
@@ -204,7 +199,7 @@ func classifySource(r *http.Request, g *authGate, ctx context.Context) (netip.Ad
 	// by which tailscale serve forwards requests to us).
 	if remoteIP.IsLoopback() {
 		if xff := firstXFF(r.Header.Get("X-Forwarded-For")); xff.IsValid() {
-			if isTailnetIP(ctx, g, xff) {
+			if isTailnetIP(xff) {
 				return xff, true
 			}
 			// XFF is set but not a tailnet IP: a misconfigured
@@ -222,7 +217,7 @@ func classifySource(r *http.Request, g *authGate, ctx context.Context) (netip.Ad
 	// direct connection from a tailnet IP (rare but possible if the
 	// operator explicitly bound the tailnet IP) is treated as
 	// tailnet, but the much more common case is a LAN address.
-	return remoteIP, isTailnetIP(ctx, g, remoteIP)
+	return remoteIP, isTailnetIP(remoteIP)
 }
 
 // firstXFF parses the first entry of an X-Forwarded-For header.
@@ -252,22 +247,14 @@ func remoteAddrIP(r *http.Request) netip.Addr {
 }
 
 // isTailnetIP reports whether ip is in Tailscale's CGNAT range
-// (the static /10 for IPv4 and /48 for IPv6) or in one of the
-// prefixes the local daemon reports as the node's own (a fallback
-// for unusual deployments).  Cached at the daemon-call layer.
-func isTailnetIP(ctx context.Context, g *authGate, ip netip.Addr) bool {
+// (the static /10 for IPv4 and /48 for IPv6).  Custom CGNAT
+// remappings are not supported here; an operator running on a
+// non-default range would need to extend this classifier.
+func isTailnetIP(ip netip.Addr) bool {
 	if !ip.IsValid() {
 		return false
 	}
-	if isTailscaleCGNAT(ip) {
-		return true
-	}
-	for _, p := range g.tc.LocalTailnetPrefixes(ctx) {
-		if p.Contains(ip) {
-			return true
-		}
-	}
-	return false
+	return isTailscaleCGNAT(ip)
 }
 
 // Tailscale's CGNAT range is fixed (RFC 6598 100.64/10 carved out

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -1,0 +1,384 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+
+	"github.com/banshee-data/velocity.report/internal/tailscale"
+)
+
+// fakePeerAuth is a hand-rolled stub of PeerAuthClient.  Function
+// fields keep tests free of mocking ceremony.
+type fakePeerAuth struct {
+	lookup   func(ip string) (tailscale.PeerIdentity, error)
+	prefixes []netip.Prefix
+}
+
+func (f *fakePeerAuth) LookupPeer(_ context.Context, remoteAddr string) (tailscale.PeerIdentity, error) {
+	if f.lookup == nil {
+		return tailscale.PeerIdentity{}, errors.New("not configured")
+	}
+	return f.lookup(remoteAddr)
+}
+
+func (f *fakePeerAuth) LocalTailnetPrefixes(_ context.Context) []netip.Prefix {
+	return f.prefixes
+}
+
+func id(view, admin bool) tailscale.PeerIdentity {
+	if admin {
+		return tailscale.PeerIdentity{View: true, Admin: true}
+	}
+	return tailscale.PeerIdentity{View: view}
+}
+
+func mkReq(remoteAddr, xff string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	r.RemoteAddr = remoteAddr
+	if xff != "" {
+		r.Header.Set("X-Forwarded-For", xff)
+	}
+	return r
+}
+
+func runGate(t *testing.T, g *authGate, kind CapKind, r *http.Request) (int, string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	g.requireCap(kind, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, r)
+	return rec.Code, rec.Body.String()
+}
+
+// --- Source classification --------------------------------------------------
+
+func TestClassifySource_XFFOnlyTrustedFromLoopback(t *testing.T) {
+	// The principal-eng review's #1: XFF must NOT be honoured when
+	// r.RemoteAddr is non-loopback, otherwise a LAN attacker who
+	// can reach :8080 directly forges a tailnet identity.
+	g := newAuthGate(&fakePeerAuth{}, EnforcementOn)
+
+	tailnetXFF := "100.64.0.5"
+
+	// Loopback upstream + XFF tailnet IP -> classified as tailnet.
+	r := mkReq("127.0.0.1:54321", tailnetXFF)
+	ip, fromTailnet := classifySource(r, g, context.Background())
+	if !fromTailnet {
+		t.Errorf("loopback+XFF tailnet: expected tailnet, got non-tailnet")
+	}
+	if ip.String() != tailnetXFF {
+		t.Errorf("loopback+XFF: ip=%s, want %s", ip, tailnetXFF)
+	}
+
+	// LAN upstream + spoofed XFF tailnet IP -> NOT tailnet.
+	// The XFF must be ignored entirely.
+	r = mkReq("192.168.1.50:33445", tailnetXFF)
+	ip, fromTailnet = classifySource(r, g, context.Background())
+	if fromTailnet {
+		t.Errorf("LAN+spoofed XFF: expected non-tailnet, got tailnet (forgery accepted)")
+	}
+	if ip.String() != "192.168.1.50" {
+		t.Errorf("LAN+spoofed XFF: ip=%s, want 192.168.1.50", ip)
+	}
+
+	// Loopback + no XFF -> loopback IP, non-tailnet (host-local).
+	r = mkReq("127.0.0.1:54321", "")
+	ip, fromTailnet = classifySource(r, g, context.Background())
+	if fromTailnet || !ip.IsLoopback() {
+		t.Errorf("loopback no XFF: ip=%s tailnet=%v, want loopback non-tailnet", ip, fromTailnet)
+	}
+}
+
+// --- CGNAT classifier ------------------------------------------------------
+
+func TestIsTailscaleCGNAT(t *testing.T) {
+	cases := map[string]bool{
+		"100.64.0.1":             true,
+		"100.127.255.255":        true,
+		"100.128.0.0":            false,
+		"10.0.0.1":               false,
+		"192.168.1.1":            false,
+		"127.0.0.1":              false,
+		"fd7a:115c:a1e0::1":      true,
+		"fd7a:115c:a1e0:abcd::1": true,
+		"fd7b:115c:a1e0::1":      false,
+		"fe80::1":                false,
+	}
+	for s, want := range cases {
+		if got := isTailscaleCGNAT(netip.MustParseAddr(s)); got != want {
+			t.Errorf("%s: got %v, want %v", s, got, want)
+		}
+	}
+}
+
+// --- Mode behaviour --------------------------------------------------------
+
+func TestRequireCap_OffMode_AllowsEverything(t *testing.T) {
+	tc := &fakePeerAuth{lookup: func(string) (tailscale.PeerIdentity, error) {
+		t.Fatal("LookupPeer must not be called when mode=off")
+		return tailscale.PeerIdentity{}, nil
+	}}
+	g := newAuthGate(tc, EnforcementOff)
+	r := mkReq("127.0.0.1:1234", "100.64.0.5")
+	if got, _ := runGate(t, g, CapAdmin, r); got != http.StatusOK {
+		t.Fatalf("off mode: got %d, want 200", got)
+	}
+}
+
+func TestRequireCap_NonTailnetSource_AlwaysAdmin(t *testing.T) {
+	tc := &fakePeerAuth{lookup: func(string) (tailscale.PeerIdentity, error) {
+		t.Fatal("LookupPeer must not be called for non-tailnet sources")
+		return tailscale.PeerIdentity{}, nil
+	}}
+	g := newAuthGate(tc, EnforcementOn)
+
+	cases := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+	}{
+		{"loopback no XFF", "127.0.0.1:1234", ""},
+		{"LAN direct", "192.168.1.10:5555", ""},
+		{"LAN with spoofed XFF", "10.0.0.1:5555", "100.64.0.99"},
+	}
+	for _, tc2 := range cases {
+		t.Run(tc2.name, func(t *testing.T) {
+			r := mkReq(tc2.remoteAddr, tc2.xff)
+			if got, _ := runGate(t, g, CapAdmin, r); got != http.StatusOK {
+				t.Fatalf("non-tailnet admin: got %d, want 200", got)
+			}
+		})
+	}
+}
+
+// --- Cap matrix ------------------------------------------------------------
+
+func TestRequireCap_GrantMatrix(t *testing.T) {
+	cases := []struct {
+		name     string
+		identity tailscale.PeerIdentity
+		required CapKind
+		want     int
+	}{
+		{"admin grants view", id(false, true), CapView, http.StatusOK},
+		{"admin grants admin", id(false, true), CapAdmin, http.StatusOK},
+		{"view allows view", id(true, false), CapView, http.StatusOK},
+		{"view denies admin", id(true, false), CapAdmin, http.StatusForbidden},
+		{"none denies view", id(false, false), CapView, http.StatusForbidden},
+		{"none denies admin", id(false, false), CapAdmin, http.StatusForbidden},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pa := &fakePeerAuth{lookup: func(string) (tailscale.PeerIdentity, error) {
+				return tc.identity, nil
+			}}
+			g := newAuthGate(pa, EnforcementOn)
+			r := mkReq("127.0.0.1:1234", "100.64.0.5")
+			if got, _ := runGate(t, g, tc.required, r); got != tc.want {
+				t.Fatalf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- Failure modes ---------------------------------------------------------
+
+func TestRequireCap_TransientLookupError_FailsOpen(t *testing.T) {
+	// Per the trust model: transient errors fail open so a
+	// tailscaled blip does not deny every authorised user at once.
+	pa := &fakePeerAuth{lookup: func(string) (tailscale.PeerIdentity, error) {
+		return tailscale.PeerIdentity{}, errors.New("socket: connection refused")
+	}}
+	g := newAuthGate(pa, EnforcementOn)
+	r := mkReq("127.0.0.1:1234", "100.64.0.5")
+	if got, _ := runGate(t, g, CapAdmin, r); got != http.StatusOK {
+		t.Fatalf("transient error: got %d, want 200 (fail-open)", got)
+	}
+}
+
+func TestRequireCap_PeerNotFound_FailsClosed(t *testing.T) {
+	// Authoritative "not a tailnet peer" -> 403 with structured body.
+	pa := &fakePeerAuth{lookup: func(string) (tailscale.PeerIdentity, error) {
+		return tailscale.PeerIdentity{}, tailscale.ErrPeerNotFound
+	}}
+	g := newAuthGate(pa, EnforcementOn)
+	r := mkReq("127.0.0.1:1234", "100.64.0.5")
+	got, body := runGate(t, g, CapAdmin, r)
+	if got != http.StatusForbidden {
+		t.Fatalf("peer-not-found: got %d, want 403", got)
+	}
+	var fb forbiddenBody
+	if err := json.Unmarshal([]byte(body), &fb); err != nil {
+		t.Fatalf("body should be JSON: %v (body: %q)", err, body)
+	}
+	if fb.Error != "unknown_peer" {
+		t.Errorf("error code = %q, want unknown_peer", fb.Error)
+	}
+	if fb.Required != "admin" {
+		t.Errorf("required = %q, want admin", fb.Required)
+	}
+}
+
+func TestRequireCap_MissingCap_StructuredBody(t *testing.T) {
+	pa := &fakePeerAuth{lookup: func(string) (tailscale.PeerIdentity, error) {
+		return id(true, false), nil // view only
+	}}
+	g := newAuthGate(pa, EnforcementOn)
+	r := mkReq("127.0.0.1:1234", "100.64.0.5")
+	got, body := runGate(t, g, CapAdmin, r)
+	if got != http.StatusForbidden {
+		t.Fatalf("missing admin cap: got %d, want 403", got)
+	}
+	var fb forbiddenBody
+	if err := json.Unmarshal([]byte(body), &fb); err != nil {
+		t.Fatalf("body should be JSON: %v (body: %q)", err, body)
+	}
+	if fb.Error != "missing_cap" {
+		t.Errorf("error code = %q, want missing_cap", fb.Error)
+	}
+}
+
+func TestRequireCap_NilClient_AllowsEverything(t *testing.T) {
+	g := newAuthGate(nil, EnforcementOn) // mode is forced to Off
+	r := mkReq("127.0.0.1:1234", "100.64.0.5")
+	if got, _ := runGate(t, g, CapAdmin, r); got != http.StatusOK {
+		t.Fatalf("nil client: got %d, want 200", got)
+	}
+}
+
+// --- Route classifier ------------------------------------------------------
+
+func TestClassifyRoute(t *testing.T) {
+	cases := []struct {
+		path, method string
+		gated        bool
+		required     CapKind
+	}{
+		// Allowlist
+		{"/", "GET", false, 0},
+		{"/app/", "GET", false, 0},
+		{"/app/index.html", "GET", false, 0},
+		{"/favicon.ico", "GET", false, 0},
+		{"/api/tailscale/status", "GET", false, 0},
+
+		// Explicit view list
+		{"/api/commands", "GET", true, CapView},
+		{"/api/config", "GET", true, CapView},
+		{"/api/events", "GET", true, CapView},
+		{"/api/version", "GET", true, CapView},
+		{"/api/timeline", "POST", true, CapView}, // method-agnostic for these
+		{"/api/charts/histogram", "GET", true, CapView},
+
+		// Mixed-method REST
+		{"/api/sites", "GET", true, CapView},
+		{"/api/sites", "POST", true, CapAdmin},
+		{"/api/sites/42", "GET", true, CapView},
+		{"/api/sites/42", "DELETE", true, CapAdmin},
+		{"/api/reports/abc", "GET", true, CapView},
+		{"/api/reports/abc", "DELETE", true, CapAdmin},
+
+		// Default-deny on anything not classified
+		{"/api/generate_report", "POST", true, CapAdmin},
+		{"/api/transit_worker", "POST", true, CapAdmin},
+		{"/api/tailscale/enable", "POST", true, CapAdmin},
+		{"/api/tailscale/disable", "POST", true, CapAdmin},
+		{"/admin/radar/command", "POST", true, CapAdmin},
+		{"/events", "GET", true, CapView},
+		{"/debug/pprof/", "GET", true, CapAdmin},          // tsweb debug routes
+		{"/debug/db/backup", "POST", true, CapAdmin},      // db admin routes
+		{"/api/lidar/runs/", "GET", true, CapAdmin},       // lidar routes default to admin
+		{"/api/totally-new-route", "GET", true, CapAdmin}, // future routes default-deny
+		{"/docs/", "GET", true, CapAdmin},                 // docsite — admin by default
+	}
+	for _, tc := range cases {
+		t.Run(tc.path+" "+tc.method, func(t *testing.T) {
+			gated, required := classifyRoute(tc.path, tc.method)
+			if gated != tc.gated {
+				t.Errorf("gated=%v, want %v", gated, tc.gated)
+			}
+			if gated && required != tc.required {
+				t.Errorf("required=%v, want %v", required, tc.required)
+			}
+		})
+	}
+}
+
+// --- ParseEnforcement ------------------------------------------------------
+
+func TestParseEnforcement(t *testing.T) {
+	cases := map[string]CapEnforcement{
+		"":      EnforcementOff,
+		"off":   EnforcementOff,
+		"OFF":   EnforcementOff,
+		"false": EnforcementOff,
+		"0":     EnforcementOff,
+		"no":    EnforcementOff,
+		"on":    EnforcementOn,
+		"true":  EnforcementOn,
+		"1":     EnforcementOn,
+		"yes":   EnforcementOn,
+	}
+	for in, want := range cases {
+		got, err := ParseEnforcement(in)
+		if err != nil {
+			t.Errorf("%q: unexpected error %v", in, err)
+		}
+		if got != want {
+			t.Errorf("%q: got %v, want %v", in, got, want)
+		}
+	}
+	for _, in := range []string{"auto", "garbage", "maybe"} {
+		if _, err := ParseEnforcement(in); err == nil {
+			t.Errorf("expected error for %q", in)
+		}
+	}
+}
+
+// --- Server-level integration ----------------------------------------------
+
+// These tests assemble a Server with the auth wrapper installed and
+// exercise it via httptest, ensuring the default-deny mux semantics
+// hold for routes the gate is not aware of.
+func TestServer_AuthWrapper_DefaultDenyForUnknownRoute(t *testing.T) {
+	// A handler attached to the mux *after* SetAuthGate is called
+	// (e.g. AttachAdminRoutes from external packages) should
+	// still be subject to the gate.  Simulate that here by
+	// registering an arbitrary "admin" route.
+	pa := &fakePeerAuth{lookup: func(string) (tailscale.PeerIdentity, error) {
+		return id(true, false), nil // view-only peer
+	}}
+	s := &Server{}
+	s.SetAuthGate(pa, EnforcementOn)
+	mux := s.ServeMux()
+	mux.HandleFunc("/debug/some-new-admin-route", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := s.authWrapper(mux)
+
+	// Tailnet-classified peer with view-only cap hitting an
+	// un-classified route -> default-deny -> 403.
+	r := mkReq("127.0.0.1:1234", "100.64.0.5")
+	r.URL.Path = "/debug/some-new-admin-route"
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, r)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("default-deny: got %d, want 403", rec.Code)
+	}
+
+	// Same peer hitting an allowlisted route -> the gate must NOT
+	// block it.  /api/tailscale/status is registered by ServeMux();
+	// we ride the existing handler to confirm the wrapper passes.
+	r = mkReq("127.0.0.1:1234", "100.64.0.5")
+	r.URL.Path = "/api/tailscale/status"
+	rec = httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, r)
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("allowlisted route was blocked: %d %q", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -15,8 +15,7 @@ import (
 // fakePeerAuth is a hand-rolled stub of PeerAuthClient.  Function
 // fields keep tests free of mocking ceremony.
 type fakePeerAuth struct {
-	lookup   func(ip string) (tailscale.PeerIdentity, error)
-	prefixes []netip.Prefix
+	lookup func(ip string) (tailscale.PeerIdentity, error)
 }
 
 func (f *fakePeerAuth) LookupPeer(_ context.Context, remoteAddr string) (tailscale.PeerIdentity, error) {
@@ -24,10 +23,6 @@ func (f *fakePeerAuth) LookupPeer(_ context.Context, remoteAddr string) (tailsca
 		return tailscale.PeerIdentity{}, errors.New("not configured")
 	}
 	return f.lookup(remoteAddr)
-}
-
-func (f *fakePeerAuth) LocalTailnetPrefixes(_ context.Context) []netip.Prefix {
-	return f.prefixes
 }
 
 func id(view, admin bool) tailscale.PeerIdentity {
@@ -61,13 +56,11 @@ func TestClassifySource_XFFOnlyTrustedFromLoopback(t *testing.T) {
 	// The principal-eng review's #1: XFF must NOT be honoured when
 	// r.RemoteAddr is non-loopback, otherwise a LAN attacker who
 	// can reach :8080 directly forges a tailnet identity.
-	g := newAuthGate(&fakePeerAuth{}, EnforcementOn)
-
 	tailnetXFF := "100.64.0.5"
 
 	// Loopback upstream + XFF tailnet IP -> classified as tailnet.
 	r := mkReq("127.0.0.1:54321", tailnetXFF)
-	ip, fromTailnet := classifySource(r, g, context.Background())
+	ip, fromTailnet := classifySource(r)
 	if !fromTailnet {
 		t.Errorf("loopback+XFF tailnet: expected tailnet, got non-tailnet")
 	}
@@ -78,7 +71,7 @@ func TestClassifySource_XFFOnlyTrustedFromLoopback(t *testing.T) {
 	// LAN upstream + spoofed XFF tailnet IP -> NOT tailnet.
 	// The XFF must be ignored entirely.
 	r = mkReq("192.168.1.50:33445", tailnetXFF)
-	ip, fromTailnet = classifySource(r, g, context.Background())
+	ip, fromTailnet = classifySource(r)
 	if fromTailnet {
 		t.Errorf("LAN+spoofed XFF: expected non-tailnet, got tailnet (forgery accepted)")
 	}
@@ -88,7 +81,7 @@ func TestClassifySource_XFFOnlyTrustedFromLoopback(t *testing.T) {
 
 	// Loopback + no XFF -> loopback IP, non-tailnet (host-local).
 	r = mkReq("127.0.0.1:54321", "")
-	ip, fromTailnet = classifySource(r, g, context.Background())
+	ip, fromTailnet = classifySource(r)
 	if fromTailnet || !ip.IsLoopback() {
 		t.Errorf("loopback no XFF: ip=%s tailnet=%v, want loopback non-tailnet", ip, fromTailnet)
 	}
@@ -261,6 +254,7 @@ func TestClassifyRoute(t *testing.T) {
 	}{
 		// Allowlist
 		{"/", "GET", false, 0},
+		{"/app", "GET", false, 0}, // bare path; mux would 301 to /app/ but wrapper runs first
 		{"/app/", "GET", false, 0},
 		{"/app/index.html", "GET", false, 0},
 		{"/favicon.ico", "GET", false, 0},
@@ -279,6 +273,8 @@ func TestClassifyRoute(t *testing.T) {
 		{"/api/sites", "POST", true, CapAdmin},
 		{"/api/sites/42", "GET", true, CapView},
 		{"/api/sites/42", "DELETE", true, CapAdmin},
+		{"/api/reports", "GET", true, CapView},   // bare list endpoint, view-gated
+		{"/api/reports", "POST", true, CapAdmin}, // mutating bare path requires admin
 		{"/api/reports/abc", "GET", true, CapView},
 		{"/api/reports/abc", "DELETE", true, CapAdmin},
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -127,6 +127,12 @@ func (s *Server) currentSerialMux() serialmux.SerialMuxInterface {
 // adding a new mutating endpoint cannot accidentally bypass auth.
 func (s *Server) SetAuthGate(tc PeerAuthClient, mode CapEnforcement) {
 	s.authGate = newAuthGate(tc, mode)
+	// One-line arming record so operators can grep journald for the
+	// transition.  The wording is referenced from
+	// docs/platform/operations/tailscale-remote-access.md.
+	if s.authGate.mode == EnforcementOn {
+		log.Print("auth: capability enforcement armed (mode=on)")
+	}
 }
 
 // viewRoutes is the allowlist of read-only endpoints that should
@@ -156,6 +162,7 @@ var viewRoutesGetOnly = []string{
 	"/api/sites",
 	"/api/sites/",
 	"/api/site_config_periods",
+	"/api/reports",
 	"/api/reports/",
 }
 
@@ -165,8 +172,12 @@ var viewRoutesGetOnly = []string{
 // belong here.
 var authAllowlist = []string{
 	// SPA static assets — the page itself must be reachable so the
-	// app can render an "unauthorized" state.
+	// app can render an "unauthorized" state.  `/app` is listed in
+	// addition to `/app/` because the auth wrapper runs before the
+	// ServeMux trailing-slash redirect, so a bare `/app` would
+	// otherwise hit default-deny instead of redirecting.
 	"/",
+	"/app",
 	"/app/",
 	"/favicon.ico",
 	// Tailscale status read so an operator with a botched grant

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -32,6 +32,7 @@ type Server struct {
 	capabilitiesProvider CapabilitiesProvider // Interface for sensor capability reporting
 	tailscale            TailscaleController  // Interface for Tailscale enable/disable/status
 	serialManager        *SerialPortManager
+	authGate             *authGate // Capability-grant authorization (nil = allow all)
 	// mux holds the HTTP handlers; storing it here ensures callers that
 	// obtain the mux via ServeMux() and register additional admin routes
 	// will have those routes preserved when Start uses the mux to run the
@@ -116,6 +117,108 @@ func (s *Server) currentSerialMux() serialmux.SerialMuxInterface {
 	return s.m
 }
 
+// SetAuthGate enables capability-grant authorization for the whole
+// HTTP surface.  When mode is EnforcementOff (or tc is nil), every
+// request is admin and no daemon calls are made.  When mode is
+// EnforcementOn, the auth wrapper installed at Start() time gates
+// every route that is not on the allowlist (see authAllowlist) at
+// CapAdmin by default; explicitly registered View routes (see
+// viewRoutes) require only CapView.  This default-deny shape means
+// adding a new mutating endpoint cannot accidentally bypass auth.
+func (s *Server) SetAuthGate(tc PeerAuthClient, mode CapEnforcement) {
+	s.authGate = newAuthGate(tc, mode)
+}
+
+// viewRoutes is the allowlist of read-only endpoints that should
+// be reachable by holders of velocity.report/cap/view.  Anything
+// not listed here defaults to CapAdmin.  Match is by exact path
+// or, when the entry ends in "/", by prefix.
+var viewRoutes = map[string]struct{}{
+	"/events":                {},
+	"/api/commands":          {},
+	"/api/events":            {},
+	"/api/radar_stats":       {},
+	"/api/config":            {},
+	"/api/capabilities":      {},
+	"/api/version":           {},
+	"/api/timeline":          {},
+	"/api/db_stats":          {},
+	"/api/charts/timeseries": {},
+	"/api/charts/histogram":  {},
+	"/api/charts/comparison": {},
+}
+
+// viewRoutesGetOnly is the allowlist of paths where GET/HEAD/OPTIONS
+// require CapView but write methods require CapAdmin.  Used for
+// REST collections that mix read and write under one mux entry
+// (e.g. /api/sites, /api/reports/).
+var viewRoutesGetOnly = []string{
+	"/api/sites",
+	"/api/sites/",
+	"/api/site_config_periods",
+	"/api/reports/",
+}
+
+// authAllowlist is the set of paths exempted from cap checks
+// entirely.  Only paths whose unauthenticated reachability is
+// either (a) a deliberate UX feature or (b) a recovery channel
+// belong here.
+var authAllowlist = []string{
+	// SPA static assets — the page itself must be reachable so the
+	// app can render an "unauthorized" state.
+	"/",
+	"/app/",
+	"/favicon.ico",
+	// Tailscale status read so an operator with a botched grant
+	// policy can still see the daemon state and recover.  Note
+	// that enable/disable are NOT on the allowlist.
+	"/api/tailscale/status",
+}
+
+// classifyRoute reports the CapKind required for path+method.  Used
+// by the wrapper installed at Start() time.  Allowlist hits return
+// (false, _).
+//
+// Match rules for both authAllowlist and viewRoutesGetOnly:
+//   - Exact path match.
+//   - If the entry ends in "/", it matches any path *strictly under*
+//     that prefix.  The root "/" is treated as exact-match only,
+//     otherwise it would absorb every URL.
+func classifyRoute(path, method string) (gated bool, required CapKind) {
+	if pathMatchesAny(path, authAllowlist) {
+		return false, 0
+	}
+	if _, ok := viewRoutes[path]; ok {
+		return true, CapView
+	}
+	if pathMatchesAny(path, viewRoutesGetOnly) {
+		switch method {
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			return true, CapView
+		default:
+			return true, CapAdmin
+		}
+	}
+	// Default-deny: anything not explicitly view-classified requires
+	// admin.  This is the property that prevents a forgotten new
+	// route from silently bypassing auth.
+	return true, CapAdmin
+}
+
+// pathMatchesAny applies the exact-or-prefix rule documented on
+// classifyRoute.  Note that "/" is exact-match only.
+func pathMatchesAny(path string, patterns []string) bool {
+	for _, p := range patterns {
+		if p == path {
+			return true
+		}
+		if p != "/" && strings.HasSuffix(p, "/") && strings.HasPrefix(path, p) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Server) ServeMux() *http.ServeMux {
 	if s.mux != nil {
 		return s.mux
@@ -124,6 +227,14 @@ func (s *Server) ServeMux() *http.ServeMux {
 
 	// Note: pprof endpoints are provided by tailscale's tsweb via db.AttachAdminRoutes()
 	// Usage: go tool pprof http://localhost:8081/debug/pprof/profile?seconds=30
+
+	// Routes are NOT gated individually here. The auth wrapper
+	// installed at Start() time gates the entire mux by classifying
+	// each request's path against viewRoutes / viewRoutesGetOnly /
+	// authAllowlist (see the maps above). This is intentional: a
+	// new route added after this point, including routes attached
+	// by external packages via mux.Handle, inherits the default-deny
+	// policy automatically.
 
 	s.mux.HandleFunc("/admin/radar/command", s.sendCommandHandler) // mutating device control: admin namespace (per cli-restructuring plan), not /api
 	s.mux.HandleFunc("/api/commands", s.listCommandsHandler)       // OPS24x command catalogue (dashboard dropdown)
@@ -134,15 +245,15 @@ func (s *Server) ServeMux() *http.ServeMux {
 	s.mux.HandleFunc("/api/version", s.showVersion)
 	s.mux.HandleFunc("/api/generate_report", s.generateReport)
 	s.mux.HandleFunc("/api/sites", s.handleSites)
-	s.mux.HandleFunc("/api/sites/", s.handleSites) // Note trailing slash to match /api/sites and /api/sites/*
+	s.mux.HandleFunc("/api/sites/", s.handleSites)
 	s.mux.HandleFunc("/api/site_config_periods", s.handleSiteConfigPeriods)
 	s.mux.HandleFunc("/api/timeline", s.handleTimeline)
-	s.mux.HandleFunc("/api/reports/", s.handleReports)                  // Report management endpoints
-	s.mux.HandleFunc("/api/transit_worker", s.handleTransitWorker)      // Transit worker control
-	s.mux.HandleFunc("/api/db_stats", s.handleDatabaseStats)            // Database table sizes and disk usage
-	s.mux.HandleFunc("/api/charts/timeseries", s.handleChartTimeSeries) // SVG time-series chart
-	s.mux.HandleFunc("/api/charts/histogram", s.handleChartHistogram)   // SVG histogram chart
-	s.mux.HandleFunc("/api/charts/comparison", s.handleChartComparison) // SVG comparison chart
+	s.mux.HandleFunc("/api/reports/", s.handleReports)
+	s.mux.HandleFunc("/api/transit_worker", s.handleTransitWorker)
+	s.mux.HandleFunc("/api/db_stats", s.handleDatabaseStats)
+	s.mux.HandleFunc("/api/charts/timeseries", s.handleChartTimeSeries)
+	s.mux.HandleFunc("/api/charts/histogram", s.handleChartHistogram)
+	s.mux.HandleFunc("/api/charts/comparison", s.handleChartComparison)
 	s.mux.HandleFunc("/api/tailscale/status", s.handleTailscaleStatus)
 	s.mux.HandleFunc("/api/tailscale/enable", s.handleTailscaleEnable)
 	s.mux.HandleFunc("/api/tailscale/disable", s.handleTailscaleDisable)
@@ -155,6 +266,27 @@ func (s *Server) ServeMux() *http.ServeMux {
 	s.mux.HandleFunc("/api/serial/devices", s.handleSerialDevices)
 	s.mux.HandleFunc("/api/serial/reload", s.handleSerialReload)
 	return s.mux
+}
+
+// authWrapper wraps next with the configured auth gate, classifying
+// each request via classifyRoute.  Returns next unchanged when the
+// gate is disabled (mode=off or no PeerAuthClient).  Installed once
+// at Start() time so it covers handlers attached after ServeMux()
+// was called (e.g. radarSerial.AttachAdminRoutes, the LiDAR routes,
+// the offline docs site).
+func (s *Server) authWrapper(next http.Handler) http.Handler {
+	if s.authGate == nil || s.authGate.mode == EnforcementOff {
+		return next
+	}
+	gate := s.authGate
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gated, required := classifyRoute(r.URL.Path, r.Method)
+		if !gated {
+			next.ServeHTTP(w, r)
+			return
+		}
+		gate.requireCap(required, next).ServeHTTP(w, r)
+	})
 }
 
 func (s *Server) sendCommandHandler(w http.ResponseWriter, r *http.Request) {
@@ -407,7 +539,9 @@ func (s *Server) startWithListener(ctx context.Context, listener net.Listener, d
 		http.NotFound(w, r)
 	})
 
-	server := &http.Server{Handler: LoggingMiddleware(mux)}
+	// Order: logging on the outside (so 403s from auth are logged),
+	// auth on the inside (so the cap check sees the real handler).
+	server := &http.Server{Handler: LoggingMiddleware(s.authWrapper(mux))}
 
 	log.Printf("HTTP server listening on %s", listener.Addr())
 

--- a/internal/cmd/server/radar.go
+++ b/internal/cmd/server/radar.go
@@ -55,21 +55,29 @@ import (
 var serveFlags = flag.NewFlagSet("velocity-serve", flag.ExitOnError)
 
 var (
-	fixtureMode   = serveFlags.Bool("fixture", false, "Load fixture to local database")
-	debugMode     = serveFlags.Bool("debug", false, "Run in debug mode (enables debug output in reports)")
-	listen        = serveFlags.String("listen", "127.0.0.1:8080", "Listen address (use 0.0.0.0:8080 for all IPv4 interfaces, or [::]:8080 for IPv4+IPv6)")
-	docsSource    = serveFlags.String("docs-source", docsite.SourceEmbed, "Offline docs source for /docs/: embed or disk")
-	port          = serveFlags.String("port", "/dev/ttySC1", "Serial port to use")
-	unitsFlag     = serveFlags.String("units", "mph", "Speed units for display (mps, mph, kmph)")
-	timezoneFlag  = serveFlags.String("timezone", "UTC", "Timezone for display (UTC, US/Eastern, US/Pacific, etc.)")
-	disableRadar  = serveFlags.Bool("disable-radar", false, "Disable radar serial port (serve DB only)")
-	dbPathFlag    = serveFlags.String("db-path", defaultRuntimeDBPath, "path to sqlite DB file (defaults to sensor_data.db)")
-	versionFlag   = serveFlags.Bool("version", false, "Print version information and exit")
-	versionShort  = serveFlags.Bool("v", false, "Print version information and exit (shorthand)")
-	configFile    = serveFlags.String("config", config.DefaultConfigPath, "Path to JSON tuning configuration file")
-	logLevel      = serveFlags.String("log-level", "ops", "LiDAR log verbosity: ops, diag, or trace")
-	selfCheck     = serveFlags.Bool("self-check", false, "Run static-build self-check (DNS, UDP, libpcap) and exit non-zero on any failure")
-	selfCheckLive = serveFlags.String("self-check-live-capture", "", "Also capture a generated UDP packet on this interface (for release validation)")
+	fixtureMode  = serveFlags.Bool("fixture", false, "Load fixture to local database")
+	debugMode    = serveFlags.Bool("debug", false, "Run in debug mode (enables debug output in reports)")
+	listen       = serveFlags.String("listen", "127.0.0.1:8080", "Listen address (use 0.0.0.0:8080 for all IPv4 interfaces, or [::]:8080 for IPv4+IPv6)")
+	docsSource   = serveFlags.String("docs-source", docsite.SourceEmbed, "Offline docs source for /docs/: embed or disk")
+	port         = serveFlags.String("port", "/dev/ttySC1", "Serial port to use")
+	unitsFlag    = serveFlags.String("units", "mph", "Speed units for display (mps, mph, kmph)")
+	timezoneFlag = serveFlags.String("timezone", "UTC", "Timezone for display (UTC, US/Eastern, US/Pacific, etc.)")
+	disableRadar = serveFlags.Bool("disable-radar", false, "Disable radar serial port (serve DB only)")
+	dbPathFlag   = serveFlags.String("db-path", defaultRuntimeDBPath, "path to sqlite DB file (defaults to sensor_data.db)")
+	versionFlag  = serveFlags.Bool("version", false, "Print version information and exit")
+	versionShort = serveFlags.Bool("v", false, "Print version information and exit (shorthand)")
+	configFile   = serveFlags.String("config", config.DefaultConfigPath, "Path to JSON tuning configuration file")
+	logLevel     = serveFlags.String("log-level", "ops", "LiDAR log verbosity: ops, diag, or trace")
+	// tsCapEnforcement controls Tailscale capability-grant authorization.
+	//   off (default): cap checks disabled; every reachable peer is admin.
+	//                  Lockout-safe by definition.
+	//   on:            cap checks enforced for tailnet-sourced requests.
+	//                  LAN/loopback peers are still admin (the LAN is the
+	//                  trust boundary in those deployments).  Recovery from
+	//                  a botched ACL: drop back to LAN access, fix grants.
+	tsCapEnforcement = serveFlags.String("ts-cap-enforcement", "off", "Tailscale capability-grant enforcement: off (default) or on")
+	selfCheck        = serveFlags.Bool("self-check", false, "Run static-build self-check (DNS, UDP, libpcap) and exit non-zero on any failure")
+	selfCheckLive    = serveFlags.String("self-check-live-capture", "", "Also capture a generated UDP packet on this interface (for release validation)")
 )
 
 const (
@@ -977,6 +985,18 @@ func Main(args []string) int {
 		tsManager.Start(ctx)
 		defer tsManager.Stop()
 		apiServer.SetTailscaleController(tsManager)
+
+		// Capability-grant authorization.  Non-Tailscale sources
+		// (loopback, LAN) are always treated as admin; only requests
+		// arriving via tailscale serve are subject to cap checks.
+		// Default mode is "off"; flip to "on" after grants are wired
+		// in the tailnet ACL.  Recovery from a botched ACL is via
+		// the LAN bypass.
+		if mode, err := api.ParseEnforcement(*tsCapEnforcement); err != nil {
+			log.Fatalf("invalid -ts-cap-enforcement: %v", err)
+		} else {
+			apiServer.SetAuthGate(tsManager, mode)
+		}
 
 		// Wire capabilities provider so /api/capabilities reports sensor state.
 		// When LiDAR is enabled we report "starting" here; the subsystem should

--- a/internal/tailscale/manager.go
+++ b/internal/tailscale/manager.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"tailscale.com/client/local"
+	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
 )
@@ -70,6 +71,7 @@ type LocalClient interface {
 	// substitute on a logged-out node.
 	Start(ctx context.Context, opts ipn.Options) error
 	WatchIPNBus(ctx context.Context, mask ipn.NotifyWatchOpt) (BusWatcher, error)
+	WhoIs(ctx context.Context, remoteAddr string) (*apitype.WhoIsResponse, error)
 }
 
 // BusWatcher is the slice of *local.IPNBusWatcher we depend on.
@@ -110,6 +112,9 @@ func (r *realLocalClient) Start(ctx context.Context, opts ipn.Options) error {
 }
 func (r *realLocalClient) WatchIPNBus(ctx context.Context, mask ipn.NotifyWatchOpt) (BusWatcher, error) {
 	return r.c.WatchIPNBus(ctx, mask)
+}
+func (r *realLocalClient) WhoIs(ctx context.Context, remoteAddr string) (*apitype.WhoIsResponse, error) {
+	return r.c.WhoIs(ctx, remoteAddr)
 }
 
 // SystemdActor performs the privileged systemd lifecycle operations
@@ -188,6 +193,11 @@ type Manager struct {
 	// rand source for backoff jitter (seeded per-Manager so multiple
 	// devices don't synchronise their reconnects).
 	rng *rand.Rand
+
+	// Caches consulted by the api layer's auth middleware.  Both are
+	// short-TTL and process-local; see peercaps.go.
+	peerCache   peerCache
+	prefixCache prefixCache
 }
 
 // Option configures a Manager at construction time.

--- a/internal/tailscale/manager.go
+++ b/internal/tailscale/manager.go
@@ -194,10 +194,9 @@ type Manager struct {
 	// devices don't synchronise their reconnects).
 	rng *rand.Rand
 
-	// Caches consulted by the api layer's auth middleware.  Both are
-	// short-TTL and process-local; see peercaps.go.
-	peerCache   peerCache
-	prefixCache prefixCache
+	// Cache consulted by the api layer's auth middleware.  Short-TTL
+	// and process-local; see peercaps.go.
+	peerCache peerCache
 }
 
 // Option configures a Manager at construction time.

--- a/internal/tailscale/manager_test.go
+++ b/internal/tailscale/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
 )
@@ -177,6 +178,7 @@ type fakeClient struct {
 	startLogin    func(ctx context.Context) error
 	start         func(ctx context.Context, opts ipn.Options) error
 	watchBus      func(ctx context.Context) (BusWatcher, error)
+	whoIs         func(ctx context.Context, remoteAddr string) (*apitype.WhoIsResponse, error)
 
 	editPrefsCalls    int32
 	setServeCfgCalls  int32
@@ -265,6 +267,13 @@ func (f *fakeClient) WatchIPNBus(ctx context.Context, mask ipn.NotifyWatchOpt) (
 		return f.watchBus(ctx)
 	}
 	return newFakeBusWatcher(), nil
+}
+
+func (f *fakeClient) WhoIs(ctx context.Context, remoteAddr string) (*apitype.WhoIsResponse, error) {
+	if f.whoIs != nil {
+		return f.whoIs(ctx, remoteAddr)
+	}
+	return nil, errors.New("whoIs not configured")
 }
 
 type fakeSystemd struct {

--- a/internal/tailscale/peercaps.go
+++ b/internal/tailscale/peercaps.go
@@ -12,7 +12,6 @@ package tailscale
 import (
 	"context"
 	"errors"
-	"net/netip"
 	"strings"
 	"sync"
 	"time"
@@ -115,23 +114,18 @@ func (m *Manager) lookupPeerUncached(ctx context.Context, remoteAddr string) (Pe
 }
 
 // isPeerNotFound reports whether err looks like the local API's
-// "address not found in NetMap" response.  The local client today
-// returns a wrapped error whose message ends in "no match for IP";
-// match conservatively to avoid widening to transient errors.
+// authoritative "no such peer" response.  The local client today
+// returns a wrapped error whose message contains "no match for IP";
+// match only that exact phrase.  Broader substrings like "not found"
+// or "404" would catch unrelated transport errors and incorrectly
+// fail closed (403) when the safe degradation is fail open.  If
+// upstream renames the phrase, we'll classify NotFound as transient
+// and fail open — the right way round if we must be wrong.
 func isPeerNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	// Cheap substring match.  Upstream may rename this; the worst
-	// case is we treat NotFound as transient and the api layer fails
-	// open instead of closed, which is the safer degradation.
-	s := err.Error()
-	for _, needle := range []string{"no match for IP", "not found", "404"} {
-		if strings.Contains(s, needle) {
-			return true
-		}
-	}
-	return false
+	return strings.Contains(err.Error(), "no match for IP")
 }
 
 // peerCacheTTL bounds how long a successful or NotFound result is
@@ -180,56 +174,4 @@ func (c *peerCache) set(k string, e peerCacheEntry) {
 	}
 	e.at = time.Now()
 	c.m[k] = e
-}
-
-// LocalTailnetPrefixes returns the IP prefixes that the tailnet
-// assigns to this node.  The result is cached for a short period
-// (the assignment effectively never changes during a session) so
-// that the per-request fallback in the api layer does not hit the
-// daemon socket on the hot path.
-func (m *Manager) LocalTailnetPrefixes(ctx context.Context) []netip.Prefix {
-	if v, ok := m.prefixCache.get(); ok {
-		return v
-	}
-	st, err := m.lc.StatusWithoutPeers(ctx)
-	if err != nil || st == nil || st.Self == nil {
-		return nil
-	}
-	out := make([]netip.Prefix, 0, len(st.Self.TailscaleIPs))
-	for _, ip := range st.Self.TailscaleIPs {
-		if !ip.IsValid() {
-			continue
-		}
-		bits := 32
-		if ip.Is6() {
-			bits = 128
-		}
-		out = append(out, netip.PrefixFrom(ip, bits))
-	}
-	m.prefixCache.set(out)
-	return out
-}
-
-const prefixCacheTTL = 30 * time.Second
-
-type prefixCache struct {
-	mu  sync.Mutex
-	val []netip.Prefix
-	at  time.Time
-}
-
-func (c *prefixCache) get() ([]netip.Prefix, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if time.Since(c.at) > prefixCacheTTL {
-		return nil, false
-	}
-	return c.val, true
-}
-
-func (c *prefixCache) set(v []netip.Prefix) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.val = v
-	c.at = time.Now()
 }

--- a/internal/tailscale/peercaps.go
+++ b/internal/tailscale/peercaps.go
@@ -1,0 +1,235 @@
+// Peer-capability lookups for HTTP authorization.
+//
+// The Manager exposes a narrow surface that the api layer uses to
+// decide whether an inbound request originated on the tailnet, and
+// whether the originating peer has any velocity.report/cap/* grants.
+// The api package depends only on the types defined here, not on
+// tailscale.com/client/tailscale/apitype, so an upstream API change
+// in apitype is contained to this file.
+
+package tailscale
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"strings"
+	"sync"
+	"time"
+
+	"tailscale.com/tailcfg"
+)
+
+// Capability names recognised by velocity.report.  The presence of
+// either grant on a peer authorises that peer for the corresponding
+// access level; the value (the JSON array on the right-hand side of
+// a grant) is unused in v1 and reserved for future per-grant
+// arguments.
+const (
+	CapView  = "velocity.report/cap/view"
+	CapAdmin = "velocity.report/cap/admin"
+)
+
+// PeerIdentity is the trimmed-down view of a tailnet peer that the
+// api layer needs.  Defining our own type (rather than re-exposing
+// apitype.WhoIsResponse) keeps the api package free of the
+// tailscale.com/client/tailscale/apitype dependency.
+type PeerIdentity struct {
+	// View is true when the peer has the velocity.report/cap/view
+	// grant (or velocity.report/cap/admin, which implies view).
+	View bool
+	// Admin is true when the peer has velocity.report/cap/admin.
+	Admin bool
+}
+
+// ErrPeerNotFound is returned by LookupPeer when the daemon is
+// reachable and authoritative but does not know the address — i.e.
+// the address is not a tailnet peer.  This is distinct from a
+// transient lookup error (network/socket/timeout) and the api layer
+// uses the distinction to fail closed only on an authoritative
+// "no such peer" result.
+var ErrPeerNotFound = errors.New("tailscale: peer not found")
+
+// LookupPeer resolves a remote address to a PeerIdentity.
+//
+// Three return paths:
+//
+//   - (PeerIdentity{...}, nil) on success, including the case where
+//     the peer exists but has no velocity.report grants (both fields
+//     false).
+//   - (PeerIdentity{}, ErrPeerNotFound) when the daemon is reachable
+//     and reports the address is not a tailnet peer.  Authoritative
+//     "no" — the api layer can fail closed.
+//   - (PeerIdentity{}, other error) on transport/timeout/socket
+//     failures.  The api layer should fail open on these to avoid
+//     a tailscaled blip locking everyone out simultaneously.
+//
+// Results are cached for a short TTL keyed on remoteAddr to keep
+// daemon traffic proportional to peer count rather than request
+// rate.  The cache is process-local, so a restart re-reads grants
+// fresh.
+func (m *Manager) LookupPeer(ctx context.Context, remoteAddr string) (PeerIdentity, error) {
+	if v, ok := m.peerCache.get(remoteAddr); ok {
+		return v.id, v.err
+	}
+	id, err := m.lookupPeerUncached(ctx, remoteAddr)
+	// Only cache definitive answers (success or NotFound).  Transient
+	// errors must be retried promptly, otherwise a 1-second outage
+	// gets amplified to peerCacheTTL of 403s.
+	if err == nil || errors.Is(err, ErrPeerNotFound) {
+		m.peerCache.set(remoteAddr, peerCacheEntry{id: id, err: err})
+	}
+	return id, err
+}
+
+func (m *Manager) lookupPeerUncached(ctx context.Context, remoteAddr string) (PeerIdentity, error) {
+	resp, err := m.lc.WhoIs(ctx, remoteAddr)
+	if err != nil {
+		// The local API does not give us a typed "not found" today;
+		// the conventional shape of the error string is matched
+		// here.  Anything else is treated as a transient error.
+		if isPeerNotFound(err) {
+			return PeerIdentity{}, ErrPeerNotFound
+		}
+		return PeerIdentity{}, err
+	}
+	if resp == nil {
+		return PeerIdentity{}, ErrPeerNotFound
+	}
+	id := PeerIdentity{}
+	for name := range resp.CapMap {
+		switch tailcfg.PeerCapability(name) {
+		case CapView:
+			id.View = true
+		case CapAdmin:
+			id.Admin = true
+		}
+	}
+	// Admin implies view at the policy level so the api layer can
+	// just check Admin/View; we still record both so a future change
+	// can distinguish them.
+	if id.Admin {
+		id.View = true
+	}
+	return id, nil
+}
+
+// isPeerNotFound reports whether err looks like the local API's
+// "address not found in NetMap" response.  The local client today
+// returns a wrapped error whose message ends in "no match for IP";
+// match conservatively to avoid widening to transient errors.
+func isPeerNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Cheap substring match.  Upstream may rename this; the worst
+	// case is we treat NotFound as transient and the api layer fails
+	// open instead of closed, which is the safer degradation.
+	s := err.Error()
+	for _, needle := range []string{"no match for IP", "not found", "404"} {
+		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// peerCacheTTL bounds how long a successful or NotFound result is
+// reused.  Short enough that a grant change in the tailnet ACL
+// propagates within a session; long enough to absorb the per-peer
+// burst of polling from the Settings page.
+const peerCacheTTL = 5 * time.Second
+
+type peerCacheEntry struct {
+	id  PeerIdentity
+	err error
+	at  time.Time
+}
+
+type peerCache struct {
+	mu sync.Mutex
+	// Entries are bounded by callers' peer set size in the typical
+	// case (a handful).  We do not cap the map: a runaway here
+	// implies a request flood from many distinct IPs, which is a
+	// separate problem worth detecting elsewhere.
+	m map[string]peerCacheEntry
+}
+
+func (c *peerCache) get(k string) (peerCacheEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.m == nil {
+		return peerCacheEntry{}, false
+	}
+	e, ok := c.m[k]
+	if !ok {
+		return peerCacheEntry{}, false
+	}
+	if time.Since(e.at) > peerCacheTTL {
+		delete(c.m, k)
+		return peerCacheEntry{}, false
+	}
+	return e, true
+}
+
+func (c *peerCache) set(k string, e peerCacheEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.m == nil {
+		c.m = make(map[string]peerCacheEntry)
+	}
+	e.at = time.Now()
+	c.m[k] = e
+}
+
+// LocalTailnetPrefixes returns the IP prefixes that the tailnet
+// assigns to this node.  The result is cached for a short period
+// (the assignment effectively never changes during a session) so
+// that the per-request fallback in the api layer does not hit the
+// daemon socket on the hot path.
+func (m *Manager) LocalTailnetPrefixes(ctx context.Context) []netip.Prefix {
+	if v, ok := m.prefixCache.get(); ok {
+		return v
+	}
+	st, err := m.lc.StatusWithoutPeers(ctx)
+	if err != nil || st == nil || st.Self == nil {
+		return nil
+	}
+	out := make([]netip.Prefix, 0, len(st.Self.TailscaleIPs))
+	for _, ip := range st.Self.TailscaleIPs {
+		if !ip.IsValid() {
+			continue
+		}
+		bits := 32
+		if ip.Is6() {
+			bits = 128
+		}
+		out = append(out, netip.PrefixFrom(ip, bits))
+	}
+	m.prefixCache.set(out)
+	return out
+}
+
+const prefixCacheTTL = 30 * time.Second
+
+type prefixCache struct {
+	mu  sync.Mutex
+	val []netip.Prefix
+	at  time.Time
+}
+
+func (c *prefixCache) get() ([]netip.Prefix, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if time.Since(c.at) > prefixCacheTTL {
+		return nil, false
+	}
+	return c.val, true
+}
+
+func (c *prefixCache) set(v []netip.Prefix) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.val = v
+	c.at = time.Now()
+}

--- a/internal/tailscale/peercaps_test.go
+++ b/internal/tailscale/peercaps_test.go
@@ -1,0 +1,186 @@
+package tailscale
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+
+	"tailscale.com/client/tailscale/apitype"
+	"tailscale.com/ipn"
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/tailcfg"
+)
+
+// peercapsClient is a minimal LocalClient that only implements the
+// methods LookupPeer and LocalTailnetPrefixes touch.  Reusing the
+// fakeClient from manager_test.go would work but pulls in too much
+// noise; this stub keeps the peercaps tests focused.
+type peercapsClient struct {
+	whoIsFn  func(ctx context.Context, remoteAddr string) (*apitype.WhoIsResponse, error)
+	statusFn func(ctx context.Context) (*ipnstate.Status, error)
+
+	whoIsCalls  atomic.Int32
+	statusCalls atomic.Int32
+}
+
+func (c *peercapsClient) Status(ctx context.Context) (*ipnstate.Status, error) {
+	return c.StatusWithoutPeers(ctx)
+}
+func (c *peercapsClient) StatusWithoutPeers(ctx context.Context) (*ipnstate.Status, error) {
+	c.statusCalls.Add(1)
+	if c.statusFn != nil {
+		return c.statusFn(ctx)
+	}
+	return &ipnstate.Status{}, nil
+}
+func (c *peercapsClient) GetPrefs(_ context.Context) (*ipn.Prefs, error) { return &ipn.Prefs{}, nil }
+func (c *peercapsClient) EditPrefs(_ context.Context, _ *ipn.MaskedPrefs) (*ipn.Prefs, error) {
+	return &ipn.Prefs{}, nil
+}
+func (c *peercapsClient) GetServeConfig(_ context.Context) (*ipn.ServeConfig, error) {
+	return &ipn.ServeConfig{}, nil
+}
+func (c *peercapsClient) SetServeConfig(_ context.Context, _ *ipn.ServeConfig) error { return nil }
+func (c *peercapsClient) StartLoginInteractive(_ context.Context) error              { return nil }
+func (c *peercapsClient) WatchIPNBus(_ context.Context, _ ipn.NotifyWatchOpt) (BusWatcher, error) {
+	return nil, errors.New("not used")
+}
+func (c *peercapsClient) WhoIs(ctx context.Context, remoteAddr string) (*apitype.WhoIsResponse, error) {
+	c.whoIsCalls.Add(1)
+	if c.whoIsFn != nil {
+		return c.whoIsFn(ctx, remoteAddr)
+	}
+	return nil, errors.New("not configured")
+}
+
+func newMgr(c LocalClient) *Manager {
+	return New(WithLocalClient(c))
+}
+
+func TestLookupPeer_AdminGrantImpliesView(t *testing.T) {
+	c := &peercapsClient{whoIsFn: func(_ context.Context, _ string) (*apitype.WhoIsResponse, error) {
+		return &apitype.WhoIsResponse{CapMap: tailcfg.PeerCapMap{
+			tailcfg.PeerCapability(CapAdmin): nil,
+		}}, nil
+	}}
+	m := newMgr(c)
+	id, err := m.LookupPeer(context.Background(), "100.64.0.5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !id.Admin || !id.View {
+		t.Errorf("admin grant should imply view: %+v", id)
+	}
+}
+
+func TestLookupPeer_ViewOnly(t *testing.T) {
+	c := &peercapsClient{whoIsFn: func(_ context.Context, _ string) (*apitype.WhoIsResponse, error) {
+		return &apitype.WhoIsResponse{CapMap: tailcfg.PeerCapMap{
+			tailcfg.PeerCapability(CapView): nil,
+		}}, nil
+	}}
+	m := newMgr(c)
+	id, _ := m.LookupPeer(context.Background(), "100.64.0.5")
+	if id.Admin {
+		t.Errorf("view-only should not have admin: %+v", id)
+	}
+	if !id.View {
+		t.Errorf("view-only should have view: %+v", id)
+	}
+}
+
+func TestLookupPeer_NoCapsIsAuthoritative(t *testing.T) {
+	c := &peercapsClient{whoIsFn: func(_ context.Context, _ string) (*apitype.WhoIsResponse, error) {
+		return &apitype.WhoIsResponse{CapMap: tailcfg.PeerCapMap{}}, nil
+	}}
+	m := newMgr(c)
+	id, err := m.LookupPeer(context.Background(), "100.64.0.5")
+	if err != nil {
+		t.Fatalf("nil error expected (peer is found, just has no caps): %v", err)
+	}
+	if id.View || id.Admin {
+		t.Errorf("peer with no caps should have neither: %+v", id)
+	}
+}
+
+func TestLookupPeer_NotFound(t *testing.T) {
+	c := &peercapsClient{whoIsFn: func(_ context.Context, _ string) (*apitype.WhoIsResponse, error) {
+		return nil, errors.New("no match for IP 192.168.1.1")
+	}}
+	m := newMgr(c)
+	_, err := m.LookupPeer(context.Background(), "192.168.1.1")
+	if !errors.Is(err, ErrPeerNotFound) {
+		t.Fatalf("expected ErrPeerNotFound, got %v", err)
+	}
+}
+
+func TestLookupPeer_TransientErrorNotCached(t *testing.T) {
+	calls := 0
+	c := &peercapsClient{whoIsFn: func(_ context.Context, _ string) (*apitype.WhoIsResponse, error) {
+		calls++
+		return nil, errors.New("connection refused")
+	}}
+	m := newMgr(c)
+	if _, err := m.LookupPeer(context.Background(), "100.64.0.5"); err == nil {
+		t.Fatal("expected error")
+	}
+	if _, err := m.LookupPeer(context.Background(), "100.64.0.5"); err == nil {
+		t.Fatal("expected error on second call")
+	}
+	if calls != 2 {
+		t.Fatalf("transient errors must not be cached: got %d daemon calls, want 2", calls)
+	}
+}
+
+func TestLookupPeer_SuccessCached(t *testing.T) {
+	c := &peercapsClient{whoIsFn: func(_ context.Context, _ string) (*apitype.WhoIsResponse, error) {
+		return &apitype.WhoIsResponse{CapMap: tailcfg.PeerCapMap{
+			tailcfg.PeerCapability(CapView): nil,
+		}}, nil
+	}}
+	m := newMgr(c)
+	for i := 0; i < 5; i++ {
+		if _, err := m.LookupPeer(context.Background(), "100.64.0.5"); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+	}
+	if got := c.whoIsCalls.Load(); got != 1 {
+		t.Errorf("expected 1 daemon call (rest cached), got %d", got)
+	}
+}
+
+func TestLookupPeer_NotFoundCached(t *testing.T) {
+	c := &peercapsClient{whoIsFn: func(_ context.Context, _ string) (*apitype.WhoIsResponse, error) {
+		return nil, errors.New("no match for IP")
+	}}
+	m := newMgr(c)
+	for i := 0; i < 3; i++ {
+		_, _ = m.LookupPeer(context.Background(), "10.0.0.1")
+	}
+	if got := c.whoIsCalls.Load(); got != 1 {
+		t.Errorf("ErrPeerNotFound should be cached: got %d daemon calls, want 1", got)
+	}
+}
+
+func TestLocalTailnetPrefixes_Cached(t *testing.T) {
+	c := &peercapsClient{statusFn: func(_ context.Context) (*ipnstate.Status, error) {
+		return &ipnstate.Status{Self: &ipnstate.PeerStatus{
+			TailscaleIPs: []netip.Addr{
+				netip.MustParseAddr("100.64.5.5"),
+				netip.MustParseAddr("fd7a:115c:a1e0::5"),
+			},
+		}}, nil
+	}}
+	m := newMgr(c)
+	for i := 0; i < 4; i++ {
+		out := m.LocalTailnetPrefixes(context.Background())
+		if len(out) != 2 {
+			t.Fatalf("got %d prefixes, want 2", len(out))
+		}
+	}
+	if got := c.statusCalls.Load(); got != 1 {
+		t.Errorf("LocalTailnetPrefixes should be cached: got %d Status calls, want 1", got)
+	}
+}

--- a/internal/tailscale/peercaps_test.go
+++ b/internal/tailscale/peercaps_test.go
@@ -3,7 +3,6 @@ package tailscale
 import (
 	"context"
 	"errors"
-	"net/netip"
 	"sync/atomic"
 	"testing"
 
@@ -14,9 +13,9 @@ import (
 )
 
 // peercapsClient is a minimal LocalClient that only implements the
-// methods LookupPeer and LocalTailnetPrefixes touch.  Reusing the
-// fakeClient from manager_test.go would work but pulls in too much
-// noise; this stub keeps the peercaps tests focused.
+// methods LookupPeer touches.  Reusing the fakeClient from
+// manager_test.go would work but pulls in too much noise; this stub
+// keeps the peercaps tests focused.
 type peercapsClient struct {
 	whoIsFn  func(ctx context.Context, remoteAddr string) (*apitype.WhoIsResponse, error)
 	statusFn func(ctx context.Context) (*ipnstate.Status, error)
@@ -44,6 +43,7 @@ func (c *peercapsClient) GetServeConfig(_ context.Context) (*ipn.ServeConfig, er
 }
 func (c *peercapsClient) SetServeConfig(_ context.Context, _ *ipn.ServeConfig) error { return nil }
 func (c *peercapsClient) StartLoginInteractive(_ context.Context) error              { return nil }
+func (c *peercapsClient) Start(_ context.Context, _ ipn.Options) error               { return nil }
 func (c *peercapsClient) WatchIPNBus(_ context.Context, _ ipn.NotifyWatchOpt) (BusWatcher, error) {
 	return nil, errors.New("not used")
 }
@@ -116,6 +116,33 @@ func TestLookupPeer_NotFound(t *testing.T) {
 	}
 }
 
+func TestLookupPeer_TransientErrorsNotMisclassified(t *testing.T) {
+	// Errors that merely contain "not found" or "404" must NOT be
+	// classified as authoritative ErrPeerNotFound — otherwise a
+	// transport blip with a generic message causes the api layer
+	// to fail closed (403) instead of fail open.
+	cases := []string{
+		"some upstream said: not found",
+		"http 404 while reading response",
+		"resource not found at /local/v0/whois",
+	}
+	for _, msg := range cases {
+		t.Run(msg, func(t *testing.T) {
+			c := &peercapsClient{whoIsFn: func(_ context.Context, _ string) (*apitype.WhoIsResponse, error) {
+				return nil, errors.New(msg)
+			}}
+			m := newMgr(c)
+			_, err := m.LookupPeer(context.Background(), "100.64.0.5")
+			if errors.Is(err, ErrPeerNotFound) {
+				t.Fatalf("err %q was misclassified as ErrPeerNotFound", msg)
+			}
+			if err == nil {
+				t.Fatalf("expected a transient error, got nil")
+			}
+		})
+	}
+}
+
 func TestLookupPeer_TransientErrorNotCached(t *testing.T) {
 	calls := 0
 	c := &peercapsClient{whoIsFn: func(_ context.Context, _ string) (*apitype.WhoIsResponse, error) {
@@ -161,26 +188,5 @@ func TestLookupPeer_NotFoundCached(t *testing.T) {
 	}
 	if got := c.whoIsCalls.Load(); got != 1 {
 		t.Errorf("ErrPeerNotFound should be cached: got %d daemon calls, want 1", got)
-	}
-}
-
-func TestLocalTailnetPrefixes_Cached(t *testing.T) {
-	c := &peercapsClient{statusFn: func(_ context.Context) (*ipnstate.Status, error) {
-		return &ipnstate.Status{Self: &ipnstate.PeerStatus{
-			TailscaleIPs: []netip.Addr{
-				netip.MustParseAddr("100.64.5.5"),
-				netip.MustParseAddr("fd7a:115c:a1e0::5"),
-			},
-		}}, nil
-	}}
-	m := newMgr(c)
-	for i := 0; i < 4; i++ {
-		out := m.LocalTailnetPrefixes(context.Background())
-		if len(out) != 2 {
-			t.Fatalf("got %d prefixes, want 2", len(out))
-		}
-	}
-	if got := c.statusCalls.Load(); got != 1 {
-		t.Errorf("LocalTailnetPrefixes should be cached: got %d Status calls, want 1", got)
 	}
 }

--- a/scripts/check-relative-links.py
+++ b/scripts/check-relative-links.py
@@ -17,6 +17,7 @@ import os
 import re
 import sys
 from pathlib import Path
+from urllib.parse import unquote
 
 # Pattern matches Markdown links: [text](target)
 # Captures the target path (group 1).
@@ -116,6 +117,12 @@ def check_file(filepath: Path, root: Path) -> list[tuple[int, str, str]]:
             path_part = target.split("#")[0]
             if not path_part:
                 continue
+
+            # Decode percent-escapes (e.g. %28 -> "(") so links to paths
+            # containing characters that must be escaped in URLs (such as the
+            # SvelteKit `(group)` route folders) resolve to real filesystem
+            # paths.
+            path_part = unquote(path_part)
 
             # Resolve relative to the directory containing the source file.
             # Use the resolved (real) path so symlinked plan files evaluate


### PR DESCRIPTION
Extend the Tailscale serve integration to optionally consume Tailscale capability grants and use these to create admin and view roles for accessing the web UI with the latter being restricted from changing device settings.

LAN access is unaffected and retains admin privileges to all endpoints.