### PR TITLE
[ci] LOC + coverage chart 📊

### DIFF
--- a/.github/workflows/loc-coverage-chart.yml
+++ b/.github/workflows/loc-coverage-chart.yml
@@ -30,6 +30,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # For workflow_run, github.sha points at the default branch tip, not
+          # the commit that produced the coverage artifacts. Pin to the
+          # triggering run's head_sha so the rendering script and the coverage
+          # data describe the same commit. workflow_dispatch falls back to the
+          # selected ref (the checkout default).
+          ref: >-
+            ${{ github.event_name == 'workflow_run'
+                && github.event.workflow_run.head_sha
+                || github.ref }}
 
       - name: Install cloc
         run: sudo apt-get update && sudo apt-get install -y cloc
@@ -48,26 +58,26 @@ jobs:
         if: github.event_name == 'workflow_run'
         run: |
           mkdir -p web/coverage tools/visualiser-macos
-          if [ -f artifacts/coverage-go/coverage.out ]; then
-            cp artifacts/coverage-go/coverage.out coverage.out
-          fi
-          if [ -f artifacts/coverage-web/lcov.info ]; then
-            cp artifacts/coverage-web/lcov.info web/coverage/lcov.info
-          fi
-          if [ -f artifacts/coverage-mac/coverage.info ]; then
-            cp artifacts/coverage-mac/coverage.info tools/visualiser-macos/coverage.info
-          fi
+          # download-artifact preserves each artifact's original upload path
+          # under artifacts/<artifact-name>/ (e.g. the web LCOV lands at
+          # artifacts/coverage-web/web/coverage/lcov.info), so locate each file
+          # by name and copy it to the canonical path the Make target expects.
+          go_cov=$(find artifacts -type f -name coverage.out | head -n1 || true)
+          web_cov=$(find artifacts -type f -name lcov.info | head -n1 || true)
+          mac_cov=$(find artifacts -type f -name coverage.info | head -n1 || true)
+          if [ -n "$go_cov" ]; then cp "$go_cov" coverage.out; \
+            else echo "no go coverage artifact found"; fi
+          if [ -n "$web_cov" ]; then cp "$web_cov" web/coverage/lcov.info; \
+            else echo "no web coverage artifact found"; fi
+          if [ -n "$mac_cov" ]; then cp "$mac_cov" tools/visualiser-macos/coverage.info; \
+            else echo "no mac coverage artifact found"; fi
           ls -la coverage.out web/coverage/lcov.info \
                  tools/visualiser-macos/coverage.info 2>/dev/null || true
 
       - name: Generate chart
-        run: |
-          mkdir -p dist
-          python3 scripts/loc-coverage-chart.py \
-            --go-coverage coverage.out \
-            --web-coverage web/coverage/lcov.info \
-            --mac-coverage tools/visualiser-macos/coverage.info \
-            --output dist/loc-coverage.svg
+        # Delegates to the canonical Make target so CI and local runs share one
+        # code path (paths/defaults owned by the Makefile).
+        run: make loc-coverage-chart
 
       - name: Upload generated chart as workflow artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/loc-coverage-chart.yml
+++ b/.github/workflows/loc-coverage-chart.yml
@@ -1,0 +1,88 @@
+name: 📊 LOC Coverage Chart
+
+# Runs after the nightly full CI succeeds on `main` and refreshes the
+# `loc-coverage.svg` asset on the orphan `stats` branch. The README embeds
+# that file via raw.githubusercontent.
+
+on:
+  workflow_run:
+    workflows: ["🌙 Nightly Full CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # required to push to the `stats` branch
+
+jobs:
+  build-chart:
+    name: "📊 Build LOC + coverage chart"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Only run if dispatched manually or the triggering nightly succeeded.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install cloc
+        run: sudo apt-get update && sudo apt-get install -y cloc
+
+      - name: Download coverage artifacts from triggering run
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          pattern: coverage-*
+          path: artifacts/
+          merge-multiple: false
+
+      - name: Stage coverage files
+        if: github.event_name == 'workflow_run'
+        run: |
+          mkdir -p web/coverage tools/visualiser-macos
+          if [ -f artifacts/coverage-go/coverage.out ]; then
+            cp artifacts/coverage-go/coverage.out coverage.out
+          fi
+          if [ -f artifacts/coverage-web/lcov.info ]; then
+            cp artifacts/coverage-web/lcov.info web/coverage/lcov.info
+          fi
+          if [ -f artifacts/coverage-mac/coverage.info ]; then
+            cp artifacts/coverage-mac/coverage.info tools/visualiser-macos/coverage.info
+          fi
+          ls -la coverage.out web/coverage/lcov.info \
+                 tools/visualiser-macos/coverage.info 2>/dev/null || true
+
+      - name: Generate chart
+        run: |
+          mkdir -p dist
+          python3 scripts/loc-coverage-chart.py \
+            --go-coverage coverage.out \
+            --web-coverage web/coverage/lcov.info \
+            --mac-coverage tools/visualiser-macos/coverage.info \
+            --output dist/loc-coverage.svg
+
+      - name: Upload generated chart as workflow artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: loc-coverage-chart
+          path: dist/loc-coverage.svg
+          retention-days: 30
+
+      - name: Publish to stats branch
+        # Only publish on main: keeps the stats branch tied to canonical
+        # history. Manual dispatches against feature branches produce the
+        # SVG as an artifact above but do not push.
+        if: >-
+          (github.event_name == 'workflow_run' &&
+           github.event.workflow_run.head_branch == 'main') ||
+          (github.event_name == 'workflow_dispatch' &&
+           github.ref == 'refs/heads/main')
+        run: scripts/publish-stats-branch.sh dist/loc-coverage.svg

--- a/.github/workflows/loc-coverage-chart.yml
+++ b/.github/workflows/loc-coverage-chart.yml
@@ -57,21 +57,21 @@ jobs:
       - name: Stage coverage files
         if: github.event_name == 'workflow_run'
         run: |
-          mkdir -p web/coverage tools/visualiser-macos
+          mkdir -p coverage tools/visualiser-macos
           # download-artifact preserves each artifact's original upload path
           # under artifacts/<artifact-name>/ (e.g. the web LCOV lands at
-          # artifacts/coverage-web/web/coverage/lcov.info), so locate each file
-          # by name and copy it to the canonical path the Make target expects.
+          # artifacts/coverage-web/coverage/lcov.info), so locate each file by
+          # name and copy it to the canonical path the Make target expects.
           go_cov=$(find artifacts -type f -name coverage.out | head -n1 || true)
           web_cov=$(find artifacts -type f -name lcov.info | head -n1 || true)
           mac_cov=$(find artifacts -type f -name coverage.info | head -n1 || true)
           if [ -n "$go_cov" ]; then cp "$go_cov" coverage.out; \
             else echo "no go coverage artifact found"; fi
-          if [ -n "$web_cov" ]; then cp "$web_cov" web/coverage/lcov.info; \
+          if [ -n "$web_cov" ]; then cp "$web_cov" coverage/lcov.info; \
             else echo "no web coverage artifact found"; fi
           if [ -n "$mac_cov" ]; then cp "$mac_cov" tools/visualiser-macos/coverage.info; \
             else echo "no mac coverage artifact found"; fi
-          ls -la coverage.out web/coverage/lcov.info \
+          ls -la coverage.out coverage/lcov.info \
                  tools/visualiser-macos/coverage.info 2>/dev/null || true
 
       - name: Generate chart

--- a/.github/workflows/nightly-full-ci.yml
+++ b/.github/workflows/nightly-full-ci.yml
@@ -120,6 +120,53 @@ jobs:
         run: |
           go test -race -tags=pcap ./internal/api/...
 
+  go-coverage:
+    name: "📈 Go Coverage"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          lfs: true
+
+      - name: Validate LFS files
+        run: ./scripts/validate-lfs-files.sh
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install system dependencies (libpcap)
+        run: sudo apt-get update && sudo apt-get install -y libpcap-dev
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Build web stub for embed
+        run: ./scripts/ensure-web-stub.sh
+
+      - name: Build offline docs stub for embed
+        run: ./scripts/ensure-docs-stub.sh
+
+      - name: Run Go tests with coverage
+        run: |
+          go test -tags=pcap -coverprofile=coverage.out -covermode=atomic \
+            $(go list ./... | grep -v '/internal/api')
+          # API tests need the minimal TeX tree which is heavy to set up here;
+          # the integration job in go-ci.yml already publishes API coverage.
+
+      - name: Upload Go coverage artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-go
+          path: coverage.out
+          if-no-files-found: warn
+          retention-days: 7
+
   web-full:
     name: "🌐 Web Full"
     runs-on: ubuntu-latest
@@ -141,6 +188,15 @@ jobs:
 
       - name: Run tests
         run: pnpm run test:ci
+
+      - name: Upload Web coverage artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-web
+          path: web/coverage/lcov.info
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Build production bundle
         run: pnpm run build
@@ -364,6 +420,15 @@ jobs:
           flags: mac
           name: mac-coverage
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload macOS coverage artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-mac
+          path: tools/visualiser-macos/coverage.info
+          if-no-files-found: warn
+          retention-days: 7
 
   performance-regression:
     name: "⚡ Performance Regression"

--- a/.github/workflows/nightly-full-ci.yml
+++ b/.github/workflows/nightly-full-ci.yml
@@ -145,18 +145,10 @@ jobs:
       - name: Download Go modules
         run: go mod download
 
-      - name: Build web stub for embed
-        run: ./scripts/ensure-web-stub.sh
-
-      - name: Build offline docs stub for embed
-        run: ./scripts/ensure-docs-stub.sh
-
       - name: Run Go tests with coverage
-        run: |
-          go test -tags=pcap -coverprofile=coverage.out -covermode=atomic \
-            $(go list ./... | grep -v '/internal/api')
-          # API tests need the minimal TeX tree which is heavy to set up here;
-          # the integration job in go-ci.yml already publishes API coverage.
+        # Canonical target owns the pcap tag, the internal/api exclusion, and
+        # the web/docs embed stubs, so the same command runs locally.
+        run: make test-go-cov-pcap
 
       - name: Upload Go coverage artifact
         if: always()

--- a/.github/workflows/nightly-full-ci.yml
+++ b/.github/workflows/nightly-full-ci.yml
@@ -186,7 +186,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-web
-          path: web/coverage/lcov.info
+          # jest's rootDir is the repo root, so the LCOV is written to
+          # coverage/lcov.info, not under web/.
+          path: coverage/lcov.info
           if-no-files-found: warn
           retention-days: 7
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Thumbs.db
 _site/
 .build/
 /build/
+/dist/
 .cache/
 .gocache/
 .gomodcache/

--- a/Makefile
+++ b/Makefile
@@ -1162,9 +1162,11 @@ coverage: test-go-cov test-web-cov test-mac-cov
 	@echo "  - macOS:  $(MAC_DIR)/coverage/TestResults.xcresult"
 
 # Render the LOC + coverage chart SVG into dist/loc-coverage.svg.
-# Reads coverage.out, $(WEB_DIR)/coverage/lcov.info, and
-# $(MAC_DIR)/coverage.info if present; any missing file degrades that bucket
-# to un-hatched with a stderr warning. Used by .github/workflows/loc-coverage-chart.yml.
+# Reads coverage.out, coverage/lcov.info, and $(MAC_DIR)/coverage.info if
+# present; any missing file degrades that bucket to un-hatched with a stderr
+# warning. The web LCOV lives at coverage/lcov.info because jest's rootDir is
+# the repo root (web/jest.config.js), so `make test-web-cov` writes there, not
+# under web/. Used by .github/workflows/loc-coverage-chart.yml.
 loc-coverage-chart:
 	@command -v cloc >/dev/null 2>&1 || { \
 	  echo "cloc not found. Install with: brew install cloc / apt-get install cloc"; \
@@ -1172,7 +1174,7 @@ loc-coverage-chart:
 	@mkdir -p dist
 	@python3 scripts/loc-coverage-chart.py \
 	  --go-coverage coverage.out \
-	  --web-coverage $(WEB_DIR)/coverage/lcov.info \
+	  --web-coverage coverage/lcov.info \
 	  --mac-coverage $(MAC_DIR)/coverage.info \
 	  --output dist/loc-coverage.svg
 	@echo "Wrote dist/loc-coverage.svg"

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ help:
 	@echo "  test                 Run aggregate tests (Go + Web + macOS)"
 	@echo "  test-go              Run Go unit tests"
 	@echo "  test-go-cov          Run Go tests with coverage"
+	@echo "  test-go-cov-pcap     Go coverage profile (pcap tag, no internal/api) for the LOC chart"
 	@echo "  test-go-coverage-summary Show coverage summary for cmd/ and internal/"
 	@echo "  test-go-changed-coverage Enforce 98% coverage for branch-added internal Go files"
 	@echo "  test-python          Run Python script/tool tests (not part of aggregate test)"
@@ -1016,7 +1017,7 @@ serial-harness: ## Run serial-harness CLI. Vars: HOST (default http://localhost:
 # TESTING
 # =============================================================================
 
-.PHONY: test test-go test-go-cov test-go-coverage-summary test-go-changed-coverage test-python test-python-cov tex-compare test-web test-web-cov test-mac test-mac-cov coverage loc-coverage-chart
+.PHONY: test test-go test-go-cov test-go-cov-pcap test-go-coverage-summary test-go-changed-coverage test-python test-python-cov tex-compare test-web test-web-cov test-mac test-mac-cov coverage loc-coverage-chart
 
 MAC_DIR = tools/visualiser-macos
 
@@ -1047,6 +1048,17 @@ test-go-cov:
 	@env -u GOROOT go test ./... -coverprofile=coverage.out -covermode=atomic
 	@env -u GOROOT go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report: coverage.html"
+
+# Go coverage profile used by the nightly LOC + coverage chart. Builds with
+# the pcap tag and excludes internal/api (whose tests need the heavy TeX tree;
+# go-ci.yml's integration job publishes API coverage separately). Emits a raw
+# coverage.out profile only — no HTML. Runnable locally for CI parity.
+test-go-cov-pcap:
+	@./scripts/ensure-web-stub.sh
+	@./scripts/ensure-docs-stub.sh
+	@echo "Running Go tests with coverage (pcap tag, excluding internal/api)..."
+	@env -u GOROOT go test -tags=pcap -coverprofile=coverage.out -covermode=atomic \
+		$$(go list ./... | grep -v '/internal/api')
 
 # Show coverage summary for cmd/ and internal/ packages
 test-go-coverage-summary:

--- a/Makefile
+++ b/Makefile
@@ -722,6 +722,7 @@ PYTHON_TEST_PATHS = \
 	scripts/test_config_tools.py \
 	scripts/test_changed_go_coverage.py \
 	scripts/test_list_matrix_fields.py \
+	scripts/test_loc_coverage_chart.py \
 	scripts/test_order_schema_tables.py \
 	scripts/test_release_radar_remote.py \
 	scripts/test_sqlite_erd.py \

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ help:
 	@echo "  test-mac             Run macOS visualiser tests (XCTest)"
 	@echo "  test-mac-cov         Run macOS tests with coverage"
 	@echo "  coverage             Generate coverage reports for all components"
+	@echo "  loc-coverage-chart   Render LOC + coverage SVG to dist/loc-coverage.svg"
 	@echo ""
 	@echo "DATABASE MIGRATIONS:"
 	@echo "  migrate-up           Apply all pending migrations"
@@ -1015,7 +1016,7 @@ serial-harness: ## Run serial-harness CLI. Vars: HOST (default http://localhost:
 # TESTING
 # =============================================================================
 
-.PHONY: test test-go test-go-cov test-go-coverage-summary test-go-changed-coverage test-python test-python-cov test-web test-web-cov test-mac test-mac-cov coverage
+.PHONY: test test-go test-go-cov test-go-coverage-summary test-go-changed-coverage test-python test-python-cov tex-compare test-web test-web-cov test-mac test-mac-cov coverage loc-coverage-chart
 
 MAC_DIR = tools/visualiser-macos
 
@@ -1146,6 +1147,22 @@ coverage: test-go-cov test-web-cov test-mac-cov
 	@echo "  - Go:     coverage.html"
 	@echo "  - Web:    $(WEB_DIR)/coverage/lcov-report/index.html"
 	@echo "  - macOS:  $(MAC_DIR)/coverage/TestResults.xcresult"
+
+# Render the LOC + coverage chart SVG into dist/loc-coverage.svg.
+# Reads coverage.out, $(WEB_DIR)/coverage/lcov.info, and
+# $(MAC_DIR)/coverage.info if present; any missing file degrades that bucket
+# to un-hatched with a stderr warning. Used by .github/workflows/loc-coverage-chart.yml.
+loc-coverage-chart:
+	@command -v cloc >/dev/null 2>&1 || { \
+	  echo "cloc not found. Install with: brew install cloc / apt-get install cloc"; \
+	  exit 1; }
+	@mkdir -p dist
+	@python3 scripts/loc-coverage-chart.py \
+	  --go-coverage coverage.out \
+	  --web-coverage $(WEB_DIR)/coverage/lcov.info \
+	  --mac-coverage $(MAC_DIR)/coverage.info \
+	  --output dist/loc-coverage.svg
+	@echo "Wrote dist/loc-coverage.svg"
 
 # Run performance regression test
 test-perf:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 </div>
 
+![Lines of code and test coverage](https://raw.githubusercontent.com/banshee-data/velocity.report/stats/loc-coverage.svg)
+
 Street-level speed measurement for neighbourhood change-makers, researchers,
 and anyone who needs evidence instead of guesswork about what traffic does.
 Radar and LiDAR sensors measure speeds and movement: no cameras, no licence plates,

--- a/scripts/loc-coverage-chart.py
+++ b/scripts/loc-coverage-chart.py
@@ -89,24 +89,47 @@ class BucketStats:
 
 
 def run_cloc(repo_root: Path) -> dict[str, int]:
-    """Return {language: code_lines} via cloc, restricted to git-tracked files."""
+    """Return {language: code_lines} via cloc, restricted to git-tracked files.
+
+    We enumerate git-tracked files ourselves and pipe them to cloc via
+    ``--list-file=-`` rather than using cloc's ``--vcs=git`` mode. That
+    sidesteps cloc's restriction that ``--exclude-dir`` accepts only bare
+    directory names (cloc 2.08 errors out on path-style entries like
+    ``web/build``) and gives us deterministic, exact control over which
+    tracked files are counted.
+    """
     if shutil.which("cloc") is None:
         sys.exit(
             "cloc not found on PATH. Install with: brew install cloc / "
             "apt-get install cloc."
         )
-    exclude_arg = ",".join(EXCLUDE_DIRS)
-    cmd = [
-        "cloc",
-        "--json",
-        "--quiet",
-        "--vcs=git",
-        "--exclude-dir=" + exclude_arg,
-        "--exclude-ext=pb.go",
-        str(repo_root),
-    ]
-    out = subprocess.run(cmd, capture_output=True, check=True, text=True)
-    payload = json.loads(out.stdout)
+    ls = subprocess.run(
+        ["git", "ls-files"],
+        cwd=repo_root,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    selected: list[str] = []
+    for path in ls.stdout.splitlines():
+        if not path:
+            continue
+        if any(path == p or path.startswith(p + "/") for p in EXCLUDE_DIRS):
+            continue
+        if path.endswith(".pb.go"):
+            continue
+        selected.append(path)
+    if not selected:
+        sys.exit("git ls-files returned no tracked files to count.")
+    proc = subprocess.run(
+        ["cloc", "--json", "--quiet", "--list-file=-"],
+        cwd=repo_root,
+        input="\n".join(selected),
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    payload = json.loads(proc.stdout)
     return {
         lang: data["code"]
         for lang, data in payload.items()

--- a/scripts/loc-coverage-chart.py
+++ b/scripts/loc-coverage-chart.py
@@ -43,11 +43,11 @@ LANGUAGE_TO_BUCKET = {
 
 # Colours sampled from the attached mock.
 COLOURS = {
-    "js":       "#ff4fb8",
-    "go":       "#7fdc2a",
-    "mac":      "#e7b27a",
+    "js": "#ff4fb8",
+    "go": "#7fdc2a",
+    "mac": "#e7b27a",
     "markdown": "#5aa6e8",
-    "scripts":  "#b4b85a",
+    "scripts": "#b4b85a",
 }
 HATCH_COLOUR = "#d72638"
 OUTLINE = "#000000"
@@ -140,8 +140,10 @@ def run_cloc(repo_root: Path) -> dict[str, int]:
 def parse_go_coverage(path: Path) -> tuple[int, int]:
     """Return (lines_hit, lines_found) approximated from Go statement counts."""
     if not path.exists():
-        print(f"warning: {path} not found; go bucket will render un-hatched.",
-              file=sys.stderr)
+        print(
+            f"warning: {path} not found; go bucket will render un-hatched.",
+            file=sys.stderr,
+        )
         return (0, 0)
     hit = found = 0
     with path.open() as fh:
@@ -165,8 +167,10 @@ def parse_go_coverage(path: Path) -> tuple[int, int]:
 def parse_lcov(path: Path, label: str) -> tuple[int, int]:
     """Return (lines_hit, lines_found) from a standard LCOV file."""
     if not path.exists():
-        print(f"warning: {path} not found; {label} bucket will render un-hatched.",
-              file=sys.stderr)
+        print(
+            f"warning: {path} not found; {label} bucket will render un-hatched.",
+            file=sys.stderr,
+        )
         return (0, 0)
     hit = found = 0
     with path.open() as fh:
@@ -213,9 +217,7 @@ CHART_Y = 40
 CHART_W = 576
 BAR_H = 44
 BAR_GAP = 12
-LABEL_FONT = (
-    "'Atkinson Hyperlegible', 'Helvetica Neue', Arial, sans-serif"
-)
+LABEL_FONT = "'Atkinson Hyperlegible', 'Helvetica Neue', Arial, sans-serif"
 
 
 def fmt_pct(numerator: int, denominator: int) -> str:
@@ -228,9 +230,16 @@ def label_for(bucket: str, loc: int, total: int) -> str:
     return f"{bucket} ({fmt_pct(loc, total)})"
 
 
-def svg_text(x: float, y: float, text: str, *,
-             anchor: str = "start", weight: str = "600",
-             size: int = 14, fill: str = TEXT) -> str:
+def svg_text(
+    x: float,
+    y: float,
+    text: str,
+    *,
+    anchor: str = "start",
+    weight: str = "600",
+    size: int = 14,
+    fill: str = TEXT,
+) -> str:
     return (
         f'<text x="{x:.1f}" y="{y:.1f}" '
         f'font-family="{LABEL_FONT}" font-size="{size}" font-weight="{weight}" '
@@ -238,17 +247,30 @@ def svg_text(x: float, y: float, text: str, *,
     )
 
 
-def svg_rect(x: float, y: float, w: float, h: float, fill: str,
-             stroke: str = OUTLINE, stroke_width: float = 2.0) -> str:
+def svg_rect(
+    x: float,
+    y: float,
+    w: float,
+    h: float,
+    fill: str,
+    stroke: str = OUTLINE,
+    stroke_width: float = 2.0,
+) -> str:
     return (
         f'<rect x="{x:.2f}" y="{y:.2f}" width="{w:.2f}" height="{h:.2f}" '
         f'fill="{fill}" stroke="{stroke}" stroke-width="{stroke_width}"/>'
     )
 
 
-def emit_segment(x: float, y: float, w: float, h: float,
-                 fill: str, hatch_id: str | None,
-                 covered_fraction: float) -> str:
+def emit_segment(
+    x: float,
+    y: float,
+    w: float,
+    h: float,
+    fill: str,
+    hatch_id: str | None,
+    covered_fraction: float,
+) -> str:
     """Solid covered region on the left, hatched uncovered on the right."""
     parts: list[str] = []
     if hatch_id is None or covered_fraction >= 1.0:
@@ -294,21 +316,25 @@ def render(buckets: dict[str, BucketStats]) -> str:
     )
     # Hatch pattern (diagonal red lines on white).
     parts.append(
-        '<defs>'
+        "<defs>"
         '<pattern id="hatch" patternUnits="userSpaceOnUse" '
         'width="8" height="8" patternTransform="rotate(45)">'
         '<rect width="8" height="8" fill="#ffffff"/>'
         f'<line x1="0" y1="0" x2="0" y2="8" stroke="{HATCH_COLOUR}" '
         'stroke-width="3"/>'
-        '</pattern>'
-        '</defs>'
+        "</pattern>"
+        "</defs>"
     )
     # Title + caption.
-    parts.append(svg_text(
-        CHART_X, 22,
-        "Lines of code · test coverage shown as hatched (uncovered)",
-        size=14, weight="700",
-    ))
+    parts.append(
+        svg_text(
+            CHART_X,
+            22,
+            "Lines of code · test coverage shown as hatched (uncovered)",
+            size=14,
+            weight="700",
+        )
+    )
 
     # Top bar: js | go | mac.
     cursor_x = CHART_X
@@ -318,65 +344,114 @@ def render(buckets: dict[str, BucketStats]) -> str:
         if b.code_loc == 0:
             continue
         seg_w = to_width(b.code_loc)
-        parts.append(emit_segment(
-            cursor_x, top_y, seg_w, BAR_H,
-            COLOURS[bucket],
-            "hatch" if b.has_coverage else None,
-            b.covered_fraction if b.has_coverage else 1.0,
-        ))
+        parts.append(
+            emit_segment(
+                cursor_x,
+                top_y,
+                seg_w,
+                BAR_H,
+                COLOURS[bucket],
+                "hatch" if b.has_coverage else None,
+                b.covered_fraction if b.has_coverage else 1.0,
+            )
+        )
         # Label: inside if there is room, else above.
         text = label_for(bucket, b.code_loc, total_loc)
         if seg_w >= 60:
-            parts.append(svg_text(
-                cursor_x + seg_w / 2, top_y + BAR_H / 2 + 5,
-                text, anchor="middle", size=14,
-            ))
+            parts.append(
+                svg_text(
+                    cursor_x + seg_w / 2,
+                    top_y + BAR_H / 2 + 5,
+                    text,
+                    anchor="middle",
+                    size=14,
+                )
+            )
         else:
-            parts.append(svg_text(
-                cursor_x + seg_w / 2, top_y - 4,
-                text, anchor="middle", size=12,
-            ))
+            parts.append(
+                svg_text(
+                    cursor_x + seg_w / 2,
+                    top_y - 4,
+                    text,
+                    anchor="middle",
+                    size=12,
+                )
+            )
         cursor_x += seg_w
 
     # Middle bar: markdown.
     mid_y = top_y + BAR_H + BAR_GAP
     md = buckets["markdown"]
     md_w = to_width(md.code_loc)
-    parts.append(emit_segment(
-        CHART_X, mid_y, md_w, BAR_H,
-        COLOURS["markdown"], None, 1.0,
-    ))
+    parts.append(
+        emit_segment(
+            CHART_X,
+            mid_y,
+            md_w,
+            BAR_H,
+            COLOURS["markdown"],
+            None,
+            1.0,
+        )
+    )
     md_label = label_for("markdown", md.code_loc, total_loc)
     if md_w >= 100:
-        parts.append(svg_text(
-            CHART_X + md_w / 2, mid_y + BAR_H / 2 + 5,
-            md_label, anchor="middle", size=14,
-        ))
+        parts.append(
+            svg_text(
+                CHART_X + md_w / 2,
+                mid_y + BAR_H / 2 + 5,
+                md_label,
+                anchor="middle",
+                size=14,
+            )
+        )
     else:
-        parts.append(svg_text(
-            CHART_X + md_w + 8, mid_y + BAR_H / 2 + 5,
-            md_label, anchor="start", size=14,
-        ))
+        parts.append(
+            svg_text(
+                CHART_X + md_w + 8,
+                mid_y + BAR_H / 2 + 5,
+                md_label,
+                anchor="start",
+                size=14,
+            )
+        )
 
     # Bottom bar: scripts.
     bot_y = mid_y + BAR_H + BAR_GAP
     sc = buckets["scripts"]
     sc_w = to_width(sc.code_loc)
-    parts.append(emit_segment(
-        CHART_X, bot_y, sc_w, BAR_H,
-        COLOURS["scripts"], None, 1.0,
-    ))
+    parts.append(
+        emit_segment(
+            CHART_X,
+            bot_y,
+            sc_w,
+            BAR_H,
+            COLOURS["scripts"],
+            None,
+            1.0,
+        )
+    )
     sc_label = label_for("scripts", sc.code_loc, total_loc)
     if sc_w >= 90:
-        parts.append(svg_text(
-            CHART_X + sc_w / 2, bot_y + BAR_H / 2 + 5,
-            sc_label, anchor="middle", size=14,
-        ))
+        parts.append(
+            svg_text(
+                CHART_X + sc_w / 2,
+                bot_y + BAR_H / 2 + 5,
+                sc_label,
+                anchor="middle",
+                size=14,
+            )
+        )
     else:
-        parts.append(svg_text(
-            CHART_X + sc_w + 8, bot_y + BAR_H / 2 + 5,
-            sc_label, anchor="start", size=14,
-        ))
+        parts.append(
+            svg_text(
+                CHART_X + sc_w + 8,
+                bot_y + BAR_H / 2 + 5,
+                sc_label,
+                anchor="start",
+                size=14,
+            )
+        )
 
     # Footer: totals so the chart is auditable on its own.
     coded_cov_hit = sum(buckets[k].cov_hit for k in CODED_BUCKETS)
@@ -397,10 +472,12 @@ def render(buckets: dict[str, BucketStats]) -> str:
 def main(argv: Iterable[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--go-coverage", type=Path, default=Path("coverage.out"))
-    p.add_argument("--web-coverage", type=Path,
-                   default=Path("web/coverage/lcov.info"))
-    p.add_argument("--mac-coverage", type=Path,
-                   default=Path("tools/visualiser-macos/coverage.info"))
+    p.add_argument("--web-coverage", type=Path, default=Path("web/coverage/lcov.info"))
+    p.add_argument(
+        "--mac-coverage",
+        type=Path,
+        default=Path("tools/visualiser-macos/coverage.info"),
+    )
     p.add_argument("--output", type=Path, required=True)
     p.add_argument("--repo-root", type=Path, default=Path("."))
     args = p.parse_args(list(argv) if argv is not None else None)

--- a/scripts/loc-coverage-chart.py
+++ b/scripts/loc-coverage-chart.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Render the LOC + coverage chart SVG embedded from the stats branch.
+
+The output is deterministic: identical inputs produce a byte-identical SVG
+so the diff on the stats branch is meaningful.
+
+Usage:
+    python3 scripts/loc-coverage-chart.py \
+        --go-coverage coverage.out \
+        --web-coverage web/coverage/lcov.info \
+        --mac-coverage tools/visualiser-macos/coverage.info \
+        --output dist/loc-coverage.svg
+
+Any missing coverage file degrades that bucket to "no hatch" with a warning
+on stderr; the LOC bar still renders.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+# Bucket → (cloc language names that map into it)
+CODED_BUCKETS = ("js", "go", "mac")
+LANGUAGE_TO_BUCKET = {
+    "TypeScript": "js",
+    "JavaScript": "js",
+    "Svelte": "js",
+    "Go": "go",
+    "Swift": "mac",
+    "Markdown": "markdown",
+    "Bourne Shell": "scripts",
+    "Bourne Again Shell": "scripts",
+    "Python": "scripts",
+    "make": "scripts",
+}
+
+# Colours sampled from the attached mock.
+COLOURS = {
+    "js":       "#ff4fb8",
+    "go":       "#7fdc2a",
+    "mac":      "#e7b27a",
+    "markdown": "#5aa6e8",
+    "scripts":  "#b4b85a",
+}
+HATCH_COLOUR = "#d72638"
+OUTLINE = "#000000"
+TEXT = "#111111"
+
+EXCLUDE_DIRS = (
+    "web/build",
+    "web/node_modules",
+    "web/.svelte-kit",
+    "coverage",
+    "web/coverage",
+    "public_html/_site",
+    "public_html/dist",
+    "tools/visualiser-macos/build",
+    "tools/visualiser-macos/DerivedData",
+    "tools/visualiser-macos/.build",
+    "tools/visualiser-macos/Packages",
+    "data",
+    "image/.pi-gen",
+)
+
+
+@dataclass
+class BucketStats:
+    code_loc: int = 0
+    cov_found: int = 0
+    cov_hit: int = 0
+    languages: list[str] = field(default_factory=list)
+
+    @property
+    def covered_fraction(self) -> float:
+        if self.cov_found <= 0:
+            return 0.0
+        return self.cov_hit / self.cov_found
+
+    @property
+    def has_coverage(self) -> bool:
+        return self.cov_found > 0
+
+
+def run_cloc(repo_root: Path) -> dict[str, int]:
+    """Return {language: code_lines} via cloc, restricted to git-tracked files."""
+    if shutil.which("cloc") is None:
+        sys.exit(
+            "cloc not found on PATH. Install with: brew install cloc / "
+            "apt-get install cloc."
+        )
+    exclude_arg = ",".join(EXCLUDE_DIRS)
+    cmd = [
+        "cloc",
+        "--json",
+        "--quiet",
+        "--vcs=git",
+        "--exclude-dir=" + exclude_arg,
+        "--exclude-ext=pb.go",
+        str(repo_root),
+    ]
+    out = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    payload = json.loads(out.stdout)
+    return {
+        lang: data["code"]
+        for lang, data in payload.items()
+        if lang not in {"header", "SUM"}
+    }
+
+
+def parse_go_coverage(path: Path) -> tuple[int, int]:
+    """Return (lines_hit, lines_found) approximated from Go statement counts."""
+    if not path.exists():
+        print(f"warning: {path} not found; go bucket will render un-hatched.",
+              file=sys.stderr)
+        return (0, 0)
+    hit = found = 0
+    with path.open() as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line or line.startswith("mode:"):
+                continue
+            try:
+                _loc, rest = line.split(":", 1)
+                _range, num_stmts_s, count_s = rest.split()
+                num_stmts = int(num_stmts_s)
+                count = int(count_s)
+            except (ValueError, IndexError):
+                continue
+            found += num_stmts
+            if count > 0:
+                hit += num_stmts
+    return (hit, found)
+
+
+def parse_lcov(path: Path, label: str) -> tuple[int, int]:
+    """Return (lines_hit, lines_found) from a standard LCOV file."""
+    if not path.exists():
+        print(f"warning: {path} not found; {label} bucket will render un-hatched.",
+              file=sys.stderr)
+        return (0, 0)
+    hit = found = 0
+    with path.open() as fh:
+        for raw in fh:
+            line = raw.strip()
+            if line.startswith("LF:"):
+                found += int(line[3:])
+            elif line.startswith("LH:"):
+                hit += int(line[3:])
+    return (hit, found)
+
+
+def build_buckets(
+    cloc_counts: dict[str, int],
+    go_cov: tuple[int, int],
+    web_cov: tuple[int, int],
+    mac_cov: tuple[int, int],
+) -> tuple[dict[str, BucketStats], list[str]]:
+    """Group cloc languages into buckets and attach coverage to coded ones."""
+    buckets: dict[str, BucketStats] = {
+        k: BucketStats() for k in ("js", "go", "mac", "markdown", "scripts")
+    }
+    other: list[str] = []
+    for lang, code in cloc_counts.items():
+        bucket = LANGUAGE_TO_BUCKET.get(lang)
+        if bucket is None:
+            other.append(f"{lang} ({code})")
+            continue
+        buckets[bucket].code_loc += code
+        buckets[bucket].languages.append(lang)
+    buckets["go"].cov_hit, buckets["go"].cov_found = go_cov
+    buckets["js"].cov_hit, buckets["js"].cov_found = web_cov
+    buckets["mac"].cov_hit, buckets["mac"].cov_found = mac_cov
+    return buckets, other
+
+
+# --- SVG rendering ----------------------------------------------------------
+
+
+VIEWBOX_W = 600
+VIEWBOX_H = 240
+CHART_X = 12
+CHART_Y = 40
+CHART_W = 576
+BAR_H = 44
+BAR_GAP = 12
+LABEL_FONT = (
+    "'Atkinson Hyperlegible', 'Helvetica Neue', Arial, sans-serif"
+)
+
+
+def fmt_pct(numerator: int, denominator: int) -> str:
+    if denominator <= 0:
+        return "0%"
+    return f"{round(100 * numerator / denominator)}%"
+
+
+def label_for(bucket: str, loc: int, total: int) -> str:
+    return f"{bucket} ({fmt_pct(loc, total)})"
+
+
+def svg_text(x: float, y: float, text: str, *,
+             anchor: str = "start", weight: str = "600",
+             size: int = 14, fill: str = TEXT) -> str:
+    return (
+        f'<text x="{x:.1f}" y="{y:.1f}" '
+        f'font-family="{LABEL_FONT}" font-size="{size}" font-weight="{weight}" '
+        f'fill="{fill}" text-anchor="{anchor}">{text}</text>'
+    )
+
+
+def svg_rect(x: float, y: float, w: float, h: float, fill: str,
+             stroke: str = OUTLINE, stroke_width: float = 2.0) -> str:
+    return (
+        f'<rect x="{x:.2f}" y="{y:.2f}" width="{w:.2f}" height="{h:.2f}" '
+        f'fill="{fill}" stroke="{stroke}" stroke-width="{stroke_width}"/>'
+    )
+
+
+def emit_segment(x: float, y: float, w: float, h: float,
+                 fill: str, hatch_id: str | None,
+                 covered_fraction: float) -> str:
+    """Solid covered region on the left, hatched uncovered on the right."""
+    parts: list[str] = []
+    if hatch_id is None or covered_fraction >= 1.0:
+        parts.append(svg_rect(x, y, w, h, fill))
+        return "".join(parts)
+    covered_w = w * covered_fraction
+    uncovered_w = w - covered_w
+    # Inset hatched fill so the outline doesn't double-stroke the seam.
+    if covered_w > 0:
+        parts.append(
+            f'<rect x="{x:.2f}" y="{y:.2f}" width="{covered_w:.2f}" '
+            f'height="{h:.2f}" fill="{fill}" stroke="none"/>'
+        )
+    if uncovered_w > 0:
+        parts.append(
+            f'<rect x="{x + covered_w:.2f}" y="{y:.2f}" '
+            f'width="{uncovered_w:.2f}" height="{h:.2f}" '
+            f'fill="url(#{hatch_id})" stroke="none"/>'
+        )
+    # Outline goes on top so the seam reads as a single bordered block.
+    parts.append(
+        f'<rect x="{x:.2f}" y="{y:.2f}" width="{w:.2f}" height="{h:.2f}" '
+        f'fill="none" stroke="{OUTLINE}" stroke-width="2"/>'
+    )
+    return "".join(parts)
+
+
+def render(buckets: dict[str, BucketStats]) -> str:
+    total_loc = sum(b.code_loc for b in buckets.values())
+    if total_loc == 0:
+        sys.exit("No LOC counted; refusing to render an empty chart.")
+
+    coded_loc = sum(buckets[k].code_loc for k in CODED_BUCKETS)
+
+    def to_width(loc: int) -> float:
+        return CHART_W * (loc / total_loc) if total_loc else 0.0
+
+    parts: list[str] = []
+    parts.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {VIEWBOX_W} {VIEWBOX_H}" '
+        f'role="img" aria-label="Lines of code by language with test coverage">'
+    )
+    # Hatch pattern (diagonal red lines on white).
+    parts.append(
+        '<defs>'
+        '<pattern id="hatch" patternUnits="userSpaceOnUse" '
+        'width="8" height="8" patternTransform="rotate(45)">'
+        '<rect width="8" height="8" fill="#ffffff"/>'
+        f'<line x1="0" y1="0" x2="0" y2="8" stroke="{HATCH_COLOUR}" '
+        'stroke-width="3"/>'
+        '</pattern>'
+        '</defs>'
+    )
+    # Title + caption.
+    parts.append(svg_text(
+        CHART_X, 22,
+        "Lines of code · test coverage shown as hatched (uncovered)",
+        size=14, weight="700",
+    ))
+
+    # Top bar: js | go | mac.
+    cursor_x = CHART_X
+    top_y = CHART_Y
+    for bucket in CODED_BUCKETS:
+        b = buckets[bucket]
+        if b.code_loc == 0:
+            continue
+        seg_w = to_width(b.code_loc)
+        parts.append(emit_segment(
+            cursor_x, top_y, seg_w, BAR_H,
+            COLOURS[bucket],
+            "hatch" if b.has_coverage else None,
+            b.covered_fraction if b.has_coverage else 1.0,
+        ))
+        # Label: inside if there is room, else above.
+        text = label_for(bucket, b.code_loc, total_loc)
+        if seg_w >= 60:
+            parts.append(svg_text(
+                cursor_x + seg_w / 2, top_y + BAR_H / 2 + 5,
+                text, anchor="middle", size=14,
+            ))
+        else:
+            parts.append(svg_text(
+                cursor_x + seg_w / 2, top_y - 4,
+                text, anchor="middle", size=12,
+            ))
+        cursor_x += seg_w
+
+    # Middle bar: markdown.
+    mid_y = top_y + BAR_H + BAR_GAP
+    md = buckets["markdown"]
+    md_w = to_width(md.code_loc)
+    parts.append(emit_segment(
+        CHART_X, mid_y, md_w, BAR_H,
+        COLOURS["markdown"], None, 1.0,
+    ))
+    md_label = label_for("markdown", md.code_loc, total_loc)
+    if md_w >= 100:
+        parts.append(svg_text(
+            CHART_X + md_w / 2, mid_y + BAR_H / 2 + 5,
+            md_label, anchor="middle", size=14,
+        ))
+    else:
+        parts.append(svg_text(
+            CHART_X + md_w + 8, mid_y + BAR_H / 2 + 5,
+            md_label, anchor="start", size=14,
+        ))
+
+    # Bottom bar: scripts.
+    bot_y = mid_y + BAR_H + BAR_GAP
+    sc = buckets["scripts"]
+    sc_w = to_width(sc.code_loc)
+    parts.append(emit_segment(
+        CHART_X, bot_y, sc_w, BAR_H,
+        COLOURS["scripts"], None, 1.0,
+    ))
+    sc_label = label_for("scripts", sc.code_loc, total_loc)
+    if sc_w >= 90:
+        parts.append(svg_text(
+            CHART_X + sc_w / 2, bot_y + BAR_H / 2 + 5,
+            sc_label, anchor="middle", size=14,
+        ))
+    else:
+        parts.append(svg_text(
+            CHART_X + sc_w + 8, bot_y + BAR_H / 2 + 5,
+            sc_label, anchor="start", size=14,
+        ))
+
+    # Footer: totals so the chart is auditable on its own.
+    coded_cov_hit = sum(buckets[k].cov_hit for k in CODED_BUCKETS)
+    coded_cov_found = sum(buckets[k].cov_found for k in CODED_BUCKETS)
+    coverage_pct = fmt_pct(coded_cov_hit, coded_cov_found)
+    footer_y = bot_y + BAR_H + 22
+    footer = (
+        f"{total_loc:,} LOC total · "
+        f"{coded_loc:,} coded ({fmt_pct(coded_loc, total_loc)}) · "
+        f"line coverage on coded: {coverage_pct}"
+    )
+    parts.append(svg_text(CHART_X, footer_y, footer, size=12, weight="500"))
+
+    parts.append("</svg>")
+    return "".join(parts) + "\n"
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--go-coverage", type=Path, default=Path("coverage.out"))
+    p.add_argument("--web-coverage", type=Path,
+                   default=Path("web/coverage/lcov.info"))
+    p.add_argument("--mac-coverage", type=Path,
+                   default=Path("tools/visualiser-macos/coverage.info"))
+    p.add_argument("--output", type=Path, required=True)
+    p.add_argument("--repo-root", type=Path, default=Path("."))
+    args = p.parse_args(list(argv) if argv is not None else None)
+
+    cloc_counts = run_cloc(args.repo_root)
+    go_cov = parse_go_coverage(args.go_coverage)
+    web_cov = parse_lcov(args.web_coverage, "js")
+    mac_cov = parse_lcov(args.mac_coverage, "mac")
+
+    buckets, other = build_buckets(cloc_counts, go_cov, web_cov, mac_cov)
+    if other:
+        print(
+            "info: cloc reported unbucketed languages (excluded from chart): "
+            + ", ".join(sorted(other)),
+            file=sys.stderr,
+        )
+
+    svg = render(buckets)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(svg)
+    print(f"Wrote {args.output} ({len(svg):,} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/publish-stats-branch.sh
+++ b/scripts/publish-stats-branch.sh
@@ -25,8 +25,9 @@ src=$(cd "$(dirname "$src")" && pwd)/$(basename "$src")
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-# Stash any local changes so checkout is clean (CI working tree has the
-# generated SVG, build artefacts, etc.).
+# Operate on the stats branch in a throwaway worktree rather than switching
+# branches here: the CI working tree is dirty (generated SVG, build artefacts,
+# coverage files) and we must not disturb it.
 work_tree=$(mktemp -d)
 trap 'rm -rf "$work_tree"' EXIT
 
@@ -49,6 +50,9 @@ if git -C "$work_tree" diff --cached --quiet; then
 fi
 
 git -C "$work_tree" commit -m "stats: refresh loc-coverage chart"
-git -C "$work_tree" push origin stats
+# --force-with-lease: stats carries only this generated asset, so we rebuild
+# it from origin/stats each run and overwrite. The lease aborts if the remote
+# moved since our fetch rather than clobbering an unexpected push.
+git -C "$work_tree" push --force-with-lease origin stats
 git worktree remove --force "$work_tree"
 echo "stats: pushed updated loc-coverage.svg"

--- a/scripts/publish-stats-branch.sh
+++ b/scripts/publish-stats-branch.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Publish the LOC + coverage chart to the orphan `stats` branch.
+#
+# Usage:
+#   scripts/publish-stats-branch.sh <path-to-loc-coverage.svg>
+#
+# Idempotent: exits 0 without pushing if the SVG content is unchanged.
+# Creates the orphan `stats` branch on first run.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <path-to-loc-coverage.svg>" >&2
+  exit 2
+fi
+
+src=$1
+if [[ ! -f "$src" ]]; then
+  echo "$src does not exist" >&2
+  exit 1
+fi
+
+# Resolve to absolute path before any branch switch.
+src=$(cd "$(dirname "$src")" && pwd)/$(basename "$src")
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+# Stash any local changes so checkout is clean (CI working tree has the
+# generated SVG, build artefacts, etc.).
+work_tree=$(mktemp -d)
+trap 'rm -rf "$work_tree"' EXIT
+
+if git ls-remote --exit-code --heads origin stats >/dev/null 2>&1; then
+  git fetch origin stats
+  git worktree add -B stats "$work_tree" origin/stats
+else
+  git worktree add --detach "$work_tree"
+  git -C "$work_tree" checkout --orphan stats
+  git -C "$work_tree" rm -rf . >/dev/null 2>&1 || true
+fi
+
+cp "$src" "$work_tree/loc-coverage.svg"
+git -C "$work_tree" add loc-coverage.svg
+
+if git -C "$work_tree" diff --cached --quiet; then
+  echo "stats: loc-coverage.svg unchanged; skipping push."
+  git worktree remove --force "$work_tree"
+  exit 0
+fi
+
+git -C "$work_tree" commit -m "stats: refresh loc-coverage chart"
+git -C "$work_tree" push origin stats
+git worktree remove --force "$work_tree"
+echo "stats: pushed updated loc-coverage.svg"

--- a/scripts/test_loc_coverage_chart.py
+++ b/scripts/test_loc_coverage_chart.py
@@ -1,0 +1,138 @@
+"""Tests for scripts/loc-coverage-chart.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "loc-coverage-chart.py"
+MODULE_NAME = "loc_coverage_chart"
+
+
+def load_module():
+    if MODULE_NAME in sys.modules:
+        return sys.modules[MODULE_NAME]
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    # Register before exec so dataclasses can resolve cls.__module__.
+    sys.modules[MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_go_coverage(tmp_path):
+    mod = load_module()
+    cov = tmp_path / "coverage.out"
+    cov.write_text(
+        "mode: atomic\n"
+        "github.com/x/y/a.go:1.0,2.0 5 1\n"
+        "github.com/x/y/a.go:3.0,4.0 3 0\n"
+        "github.com/x/y/b.go:1.0,2.0 2 7\n"
+    )
+    hit, found = mod.parse_go_coverage(cov)
+    assert (hit, found) == (7, 10)
+
+
+def test_parse_go_coverage_missing(tmp_path):
+    mod = load_module()
+    assert mod.parse_go_coverage(tmp_path / "nope.out") == (0, 0)
+
+
+def test_parse_lcov(tmp_path):
+    mod = load_module()
+    lcov = tmp_path / "lcov.info"
+    lcov.write_text(
+        "SF:src/a.ts\n"
+        "DA:1,1\nDA:2,0\n"
+        "LF:10\nLH:7\n"
+        "end_of_record\n"
+        "SF:src/b.ts\n"
+        "LF:5\nLH:2\n"
+        "end_of_record\n"
+    )
+    hit, found = mod.parse_lcov(lcov, "js")
+    assert (hit, found) == (9, 15)
+
+
+def test_build_buckets_groups_languages_and_attaches_coverage():
+    mod = load_module()
+    cloc_counts = {
+        "Go": 1000,
+        "TypeScript": 300,
+        "Svelte": 100,
+        "Swift": 500,
+        "Markdown": 800,
+        "Python": 50,
+        "Bourne Again Shell": 25,
+        "Rust": 999,  # unbucketed — should appear in `other`
+    }
+    buckets, other = mod.build_buckets(
+        cloc_counts,
+        go_cov=(700, 1000),
+        web_cov=(200, 400),
+        mac_cov=(100, 500),
+    )
+    assert buckets["go"].code_loc == 1000
+    assert buckets["js"].code_loc == 400
+    assert buckets["mac"].code_loc == 500
+    assert buckets["markdown"].code_loc == 800
+    assert buckets["scripts"].code_loc == 75
+    assert buckets["go"].covered_fraction == pytest.approx(0.7)
+    assert buckets["js"].covered_fraction == pytest.approx(0.5)
+    assert buckets["mac"].covered_fraction == pytest.approx(0.2)
+    assert other == ["Rust (999)"]
+
+
+def test_render_emits_svg_with_pattern_and_categories():
+    mod = load_module()
+    buckets = {
+        "js": mod.BucketStats(code_loc=400, cov_hit=200, cov_found=400),
+        "go": mod.BucketStats(code_loc=1000, cov_hit=700, cov_found=1000),
+        "mac": mod.BucketStats(code_loc=500, cov_hit=100, cov_found=500),
+        "markdown": mod.BucketStats(code_loc=800),
+        "scripts": mod.BucketStats(code_loc=75),
+    }
+    svg = mod.render(buckets)
+    assert svg.startswith("<svg")
+    assert svg.rstrip().endswith("</svg>")
+    assert 'id="hatch"' in svg
+    # Each named bucket should produce a label.
+    for label in ("js (", "go (", "mac (", "markdown (", "scripts ("):
+        assert label in svg
+    # Totals footer present and human-readable.
+    assert "LOC total" in svg
+    assert "line coverage on coded" in svg
+
+
+def test_render_omits_zero_loc_segments():
+    mod = load_module()
+    buckets = {
+        "js": mod.BucketStats(code_loc=0),
+        "go": mod.BucketStats(code_loc=100, cov_hit=50, cov_found=100),
+        "mac": mod.BucketStats(code_loc=0),
+        "markdown": mod.BucketStats(code_loc=200),
+        "scripts": mod.BucketStats(code_loc=10),
+    }
+    svg = mod.render(buckets)
+    assert "js (" not in svg
+    assert "mac (" not in svg
+    assert "go (" in svg
+
+
+def test_render_is_deterministic():
+    mod = load_module()
+    buckets = {
+        "js": mod.BucketStats(code_loc=400, cov_hit=200, cov_found=400),
+        "go": mod.BucketStats(code_loc=1000, cov_hit=700, cov_found=1000),
+        "mac": mod.BucketStats(code_loc=500, cov_hit=100, cov_found=500),
+        "markdown": mod.BucketStats(code_loc=800),
+        "scripts": mod.BucketStats(code_loc=75),
+    }
+    a = mod.render(buckets)
+    b = mod.render(buckets)
+    assert a == b


### PR DESCRIPTION
Renders a horizontal stacked SVG showing the line-of-code breakdown across js / go / mac / markdown / scripts, with a hatched overlay marking the uncovered share of each coded language. The README embeds the chart from a dedicated orphan `stats` branch so neither main nor public_html churn each night.

A new `loc-coverage-chart.yml` workflow is triggered by `workflow_run` after the nightly full CI succeeds on main, downloads coverage artifacts from the triggering run, runs `cloc --vcs=git`, parses the three coverage formats (Go cover + LCOV x2), and force-pushes the SVG to `stats` only when its content actually changes.

Nightly CI now publishes the three coverage payloads as artifacts (`coverage-go`, `coverage-web`, `coverage-mac`) and a new `go-coverage` job produces the merged Go profile under `-tags=pcap`. A `make loc-coverage-chart` target renders the same SVG locally for iterating on the renderer without pushing.

# Purpose
This pull request introduces an automated workflow for generating and publishing a combined Lines of Code (LOC) and test coverage SVG chart, integrating it into the nightly CI process and the project documentation. The changes add a new GitHub Actions workflow, updates to the Makefile for local chart generation, scripts for publishing and testing the chart, and modifications to the README to display the chart. This provides continuous visibility into codebase size and test coverage across Go, web, and macOS components.

**Automated LOC + Coverage Chart Generation and Publishing**

* Added a new GitHub Actions workflow (`.github/workflows/loc-coverage-chart.yml`) to generate and publish an SVG chart showing LOC and test coverage after nightly CI runs or on manual dispatch. The chart is published to a dedicated `stats` branch for embedding.
* Updated the nightly CI workflow to upload Go (`coverage.out`), web (`lcov.info`), and macOS (`coverage.info`) coverage artifacts, enabling the LOC + coverage chart to aggregate data from all major components. [[1]](diffhunk://#diff-8f0f8c70508e99249ae901f4aae491104653ba1abc3b6a1f00012b415dc7e756R132-R178) [[2]](diffhunk://#diff-8f0f8c70508e99249ae901f4aae491104653ba1abc3b6a1f00012b415dc7e756R201-R209) [[3]](diffhunk://#diff-8f0f8c70508e99249ae901f4aae491104653ba1abc3b6a1f00012b415dc7e756R433-R441)

**Makefile and Local Developer Tooling**

* Added `loc-coverage-chart` target to the `Makefile` for local SVG chart generation, including help text and phony rule. This runs the Python script and ensures `cloc` is installed. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R93) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L954-R955) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1080-R1095)

**Publishing and Testing Scripts**

* Introduced `scripts/publish-stats-branch.sh`, a robust script that publishes the generated SVG to the orphan `stats` branch only when the chart changes, ensuring efficient and idempotent updates.
* Added `scripts/test_loc_coverage_chart.py` with comprehensive tests for the chart generation logic, including coverage parsing, bucket grouping, SVG rendering, and determinism.

**Documentation**

* Embedded the generated LOC + coverage SVG chart in the `README.md`, providing an always-up-to-date visual summary of codebase size and test coverage for all contributors and users.# Changes

# Checklist

- [ ] Uses British English spelling/wording where applicable.
- [ ] Design is confirmed and aligns with `DESIGN.md`.
- [ ] Any maths/derived values are valid and up to date.
- [ ] Version has been bumped where required.
- [ ] Documentation is up to date.
- [ ] `README.md` is up to date.
- [ ] `docs/DEVLOG.md` is up to date.
