### PR TITLE
[docs] recover OBB guard-stack validation notes

### DIFF
--- a/config/CONFIG.md
+++ b/config/CONFIG.md
@@ -262,31 +262,31 @@ Maths: [clustering-maths.md](../data/maths/clustering-maths.md),
 
 Maths: [tracking-maths.md](../data/maths/tracking-maths.md)
 
-| Path                                              | Type    | Primary consumer                                                              | Notes                                       |
-| ------------------------------------------------- | ------- | ----------------------------------------------------------------------------- | ------------------------------------------- |
-| `l5.engine`                                       | string  | [(\*L5Config).ActiveCommon](../internal/config/tuning_accessors.go)           | Active L5 engine.                           |
-| `l5.cv_kf_v1.gating_distance_squared`             | float64 | [GetGatingDistanceSquared](../internal/config/tuning_accessors.go)            | Mahalanobis association gate.               |
-| `l5.cv_kf_v1.process_noise_pos`                   | float64 | [GetProcessNoisePos](../internal/config/tuning_accessors.go)                  | Position process noise.                     |
-| `l5.cv_kf_v1.process_noise_vel`                   | float64 | [GetProcessNoiseVel](../internal/config/tuning_accessors.go)                  | Velocity process noise.                     |
-| `l5.cv_kf_v1.measurement_noise`                   | float64 | [GetMeasurementNoise](../internal/config/tuning_accessors.go)                 | Measurement noise.                          |
-| `l5.cv_kf_v1.occlusion_cov_inflation`             | float64 | [GetOcclusionCovInflation](../internal/config/tuning_accessors.go)            | Coast-mode covariance inflation.            |
-| `l5.cv_kf_v1.hits_to_confirm`                     | int     | [GetHitsToConfirm](../internal/config/tuning_accessors.go)                    | Hits required for confirmation.             |
-| `l5.cv_kf_v1.max_misses`                          | int     | [GetMaxMisses](../internal/config/tuning_accessors.go)                        | Tentative-track miss budget.                |
-| `l5.cv_kf_v1.max_misses_confirmed`                | int     | [GetMaxMissesConfirmed](../internal/config/tuning_accessors.go)               | Confirmed-track miss budget.                |
-| `l5.cv_kf_v1.max_tracks`                          | int     | [GetMaxTracks](../internal/config/tuning_accessors.go)                        | Tracker capacity, validated in `[1,1000]`.  |
-| `l5.cv_kf_v1.max_reasonable_speed_mps`            | float64 | [GetMaxReasonableSpeedMps](../internal/config/tuning_accessors.go)            | Speed sanity limit.                         |
-| `l5.cv_kf_v1.max_position_jump_metres`            | float64 | [GetMaxPositionJumpMetres](../internal/config/tuning_accessors.go)            | Max plausible position jump.                |
-| `l5.cv_kf_v1.max_predict_dt`                      | float64 | [GetMaxPredictDt](../internal/config/tuning_accessors.go)                     | Maximum prediction horizon.                 |
-| `l5.cv_kf_v1.max_covariance_diag`                 | float64 | [GetMaxCovarianceDiag](../internal/config/tuning_accessors.go)                | Covariance clamp.                           |
-| `l5.cv_kf_v1.min_points_for_pca`                  | int     | [GetMinPointsForPCA](../internal/config/tuning_accessors.go)                  | Minimum points for OBB PCA.                 |
-| `l5.cv_kf_v1.obb_heading_smoothing_alpha`         | float64 | [GetOBBHeadingSmoothingAlpha](../internal/config/tuning_accessors.go)         | Heading smoothing factor.                   |
-| `l5.cv_kf_v1.obb_aspect_ratio_lock_threshold`     | float64 | [GetOBBAspectRatioLockThreshold](../internal/config/tuning_accessors.go)      | Heading lock threshold.                     |
-| `l5.cv_kf_v1.max_track_history_length`            | int     | [GetMaxTrackHistoryLength](../internal/config/tuning_accessors.go)            | Track history capacity.                     |
-| `l5.cv_kf_v1.max_speed_history_length`            | int     | [GetMaxSpeedHistoryLength](../internal/config/tuning_accessors.go)            | Speed history capacity.                     |
-| `l5.cv_kf_v1.merge_size_ratio`                    | float64 | [GetMergeSizeRatio](../internal/config/tuning_accessors.go)                   | Merge heuristic ratio.                      |
-| `l5.cv_kf_v1.split_size_ratio`                    | float64 | [GetSplitSizeRatio](../internal/config/tuning_accessors.go)                   | Split heuristic ratio.                      |
-| `l5.cv_kf_v1.deleted_track_grace_period`          | string  | [GetDeletedTrackGracePeriod](../internal/config/tuning_accessors.go)          | Deleted-track reuse window.                 |
-| `l5.cv_kf_v1.min_observations_for_classification` | int     | [GetMinObservationsForClassification](../internal/config/tuning_accessors.go) | Minimum observations before classification. |
+| Path                                              | Type    | Primary consumer                                                              | Notes                                                                                        |
+| ------------------------------------------------- | ------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `l5.engine`                                       | string  | [(\*L5Config).ActiveCommon](../internal/config/tuning_accessors.go)           | Active L5 engine.                                                                            |
+| `l5.cv_kf_v1.gating_distance_squared`             | float64 | [GetGatingDistanceSquared](../internal/config/tuning_accessors.go)            | Mahalanobis association gate.                                                                |
+| `l5.cv_kf_v1.process_noise_pos`                   | float64 | [GetProcessNoisePos](../internal/config/tuning_accessors.go)                  | Position process noise.                                                                      |
+| `l5.cv_kf_v1.process_noise_vel`                   | float64 | [GetProcessNoiseVel](../internal/config/tuning_accessors.go)                  | Velocity process noise.                                                                      |
+| `l5.cv_kf_v1.measurement_noise`                   | float64 | [GetMeasurementNoise](../internal/config/tuning_accessors.go)                 | Measurement noise.                                                                           |
+| `l5.cv_kf_v1.occlusion_cov_inflation`             | float64 | [GetOcclusionCovInflation](../internal/config/tuning_accessors.go)            | Coast-mode covariance inflation.                                                             |
+| `l5.cv_kf_v1.hits_to_confirm`                     | int     | [GetHitsToConfirm](../internal/config/tuning_accessors.go)                    | Hits required for confirmation.                                                              |
+| `l5.cv_kf_v1.max_misses`                          | int     | [GetMaxMisses](../internal/config/tuning_accessors.go)                        | Tentative-track miss budget.                                                                 |
+| `l5.cv_kf_v1.max_misses_confirmed`                | int     | [GetMaxMissesConfirmed](../internal/config/tuning_accessors.go)               | Confirmed-track miss budget.                                                                 |
+| `l5.cv_kf_v1.max_tracks`                          | int     | [GetMaxTracks](../internal/config/tuning_accessors.go)                        | Tracker capacity, validated in `[1,1000]`.                                                   |
+| `l5.cv_kf_v1.max_reasonable_speed_mps`            | float64 | [GetMaxReasonableSpeedMps](../internal/config/tuning_accessors.go)            | Speed sanity limit.                                                                          |
+| `l5.cv_kf_v1.max_position_jump_metres`            | float64 | [GetMaxPositionJumpMetres](../internal/config/tuning_accessors.go)            | Max plausible position jump.                                                                 |
+| `l5.cv_kf_v1.max_predict_dt`                      | float64 | [GetMaxPredictDt](../internal/config/tuning_accessors.go)                     | Maximum prediction horizon.                                                                  |
+| `l5.cv_kf_v1.max_covariance_diag`                 | float64 | [GetMaxCovarianceDiag](../internal/config/tuning_accessors.go)                | Covariance clamp.                                                                            |
+| `l5.cv_kf_v1.min_points_for_pca`                  | int     | [GetMinPointsForPCA](../internal/config/tuning_accessors.go)                  | Minimum points for OBB PCA.                                                                  |
+| `l5.cv_kf_v1.obb_heading_smoothing_alpha`         | float64 | [GetOBBHeadingSmoothingAlpha](../internal/config/tuning_accessors.go)         | Heading smoothing factor.                                                                    |
+| `l5.cv_kf_v1.obb_aspect_ratio_lock_threshold`     | float64 | [GetOBBAspectRatioLockThreshold](../internal/config/tuning_accessors.go)      | Heading lock threshold; default `0.25`, with `0.15` / `0.10` reserved for replay validation. |
+| `l5.cv_kf_v1.max_track_history_length`            | int     | [GetMaxTrackHistoryLength](../internal/config/tuning_accessors.go)            | Track history capacity.                                                                      |
+| `l5.cv_kf_v1.max_speed_history_length`            | int     | [GetMaxSpeedHistoryLength](../internal/config/tuning_accessors.go)            | Speed history capacity.                                                                      |
+| `l5.cv_kf_v1.merge_size_ratio`                    | float64 | [GetMergeSizeRatio](../internal/config/tuning_accessors.go)                   | Merge heuristic ratio.                                                                       |
+| `l5.cv_kf_v1.split_size_ratio`                    | float64 | [GetSplitSizeRatio](../internal/config/tuning_accessors.go)                   | Split heuristic ratio.                                                                       |
+| `l5.cv_kf_v1.deleted_track_grace_period`          | string  | [GetDeletedTrackGracePeriod](../internal/config/tuning_accessors.go)          | Deleted-track reuse window.                                                                  |
+| `l5.cv_kf_v1.min_observations_for_classification` | int     | [GetMinObservationsForClassification](../internal/config/tuning_accessors.go) | Minimum observations before classification.                                                  |
 
 ### Pipeline
 

--- a/data/maths/MATHS.md
+++ b/data/maths/MATHS.md
@@ -99,8 +99,10 @@ The production pipeline uses four math-heavy layers:
 - [OBB Heading Stability Review](proposals/20260222-obb-heading-stability-review.md): **Partially Implemented**.
   Root cause analysis of spinning bounding boxes:
   PCA ambiguity, axis swaps, dimension averaging, and renderer mismatches.
-  Guard 3 (90° jump rejection), fixes B, C, G applied;
-  remaining fixes superseded by geometry-coherent model.
+  Guard 3 (90° jump rejection) plus fixes B, C, and G are applied.
+  Fix D remains a config-only threshold validation item: current defaults still use `0.25`,
+  with `0.15` / `0.10` kept as replay candidates. Fixes E/F remain optional diagnostic
+  work and should not expand the guard stack before geometry-coherent tracking.
 - [Geometry-Coherent Track State](proposals/20260222-geometry-coherent-tracking.md):
   Per-track Bayesian geometry model replacing reactive guards with axis selection via likelihood
   test, uncertainty-gated EMA updates, shape classification, and heading-motion coupling.
@@ -151,10 +153,9 @@ heading prior when velocity data is available.
 boxes that spin, change shape, or fail to capture all cluster points). No
 upstream changes required.
 
-**Remaining OBB review work subsumed:** Fixes D (threshold tuning), E (renderer
-consistency), and F (debug cluster rendering) from the
-[OBB heading stability review](proposals/20260222-obb-heading-stability-review.md)
-become unnecessary once the geometry-coherent model replaces the guards.
+**Guard-stack note:** Geometry-coherent tracking still supersedes the current
+OBB guard stack. Pre-P1 work should stay limited to threshold validation,
+telemetry, and debug-only inspection rather than adding new public guard surfaces.
 
 ### P2: velocity-coherent foreground extraction
 
@@ -235,12 +236,15 @@ structure to build a redundant anchor set.
 ### Maintenance: OBB heading stability review (remaining items)
 
 **Source:** [obb-heading-stability-review.md](proposals/20260222-obb-heading-stability-review.md)
-**Status:** Guard 3, fixes B, C, G **implemented**. Fix D (config-only), E, F not started.
+**Status:** Guard 3 and fixes B, C, G **implemented**. Fix D is config-only but
+not landed in the shipped defaults; Fixes E/F are diagnostic follow-ups, not
+guard-stack expansion work.
 
-Fix D (tighten aspect-ratio lock threshold) is a low-risk config change that
-can be applied any time. Fixes E and F provide incremental improvement but
-are **superseded by P1**: once the geometry-coherent model lands, the guards
-they improve will be removed.
+Keep the default `obb_aspect_ratio_lock_threshold` at `0.25` until a fixed
+replay pack supports a stricter value. Compare `0.25`, `0.15`, and `0.10`
+using heading jitter, fragmentation, empty-box ratio, and labelled composite
+score where labels exist. Use heading-source rendering / `heading_source` API
+data to baseline the current guard stack before replacing it with P1.
 
 ## Config mapping
 

--- a/data/maths/MATHS.md
+++ b/data/maths/MATHS.md
@@ -328,7 +328,7 @@ rather than mathematical source).
 - Future engine `imm_cv_ca_rts_eval_v2` extends `imm_cv_ca_v2` with: `rts_smoothing_window`.
 - Getter/source path: [internal/config/tuning.go](../../internal/config/tuning.go) (`L5Common`)
 - Runtime mapping:
-  - [internal/lidar/l5tracks/tracking.go](../../internal/lidar/l5tracks/tracking.go) (`TrackerConfigFromTuning`)
+  - [internal/lidar/l5tracks/tracking_config.go](../../internal/lidar/l5tracks/tracking_config.go) (`TrackerConfigFromTuning`)
   - Tracker wiring in [internal/cmd/server/radar.go](../../internal/cmd/server/radar.go)
 
 ### L1 sensor and data source

--- a/data/maths/proposals/20260222-geometry-coherent-tracking.md
+++ b/data/maths/proposals/20260222-geometry-coherent-tracking.md
@@ -499,8 +499,17 @@ Parameters should be validated and tuned through:
 **Phase 1:** Implement core geometry state + axis selection
 
 - Replaces Guards 2 & 3
-- Can run in parallel with current system for A/B testing
-- Measure dimension stability, heading drift, flip frequency
+- Run behind `TrackerInterface` for A/B testing; keep geometry parameters in an
+  internal config struct and do not add a public runtime engine selector before
+  `v0.5.0`.
+- Baseline the current tracker first using `HeadingJitterDeg`,
+  per-track `heading_source`, aspect-ratio-lock cases, and replay-derived
+  fragmentation / empty-box ratios.
+- Promote only if the fixed replay pack shows equal-or-lower heading jitter on
+  target near-square / slow-motion scenarios, no more than 5% regression in
+  fragmentation, empty-box ratio, or unbounded-point ratio, no material speed
+  correlation regression, and equal-or-better labelled composite score where
+  reference labels exist.
 
 **Phase 2:** Add shape classification
 
@@ -626,4 +635,6 @@ For ambiguous tracks, maintain multiple geometry hypotheses:
 ---
 
 **Proposal Status:** Awaiting review and experimental validation.
-**Next Steps:** Implement Phase 1 (core geometry state + axis selection) for A/B testing against current system.
+**Next Steps:** Implement Phase 1 (core geometry state + axis selection) behind
+`TrackerInterface` for A/B testing against the current system, and do not
+switch the default tracker until the replay gate above passes.

--- a/data/maths/proposals/20260222-geometry-coherent-tracking.md
+++ b/data/maths/proposals/20260222-geometry-coherent-tracking.md
@@ -11,7 +11,7 @@
 
 ## 1. Problem statement
 
-The current LiDAR tracking system computes oriented bounding boxes (OBB) from Principal Component Analysis (PCA) on each frame's cluster points independently (`l4perception/obb.go`). To address instability, four guards are applied at the tracker level (`l5tracks/tracking.go`):
+The current LiDAR tracking system computes oriented bounding boxes (OBB) from Principal Component Analysis (PCA) on each frame's cluster points independently (`l4perception/obb.go`). To address instability, four guards are applied in the tracker update path (`l5tracks/tracking_update.go`):
 
 1. **Guard 1:** Minimum point count threshold
 2. **Guard 2:** Aspect-ratio lock threshold
@@ -327,12 +327,12 @@ L5 Tracking (proposed changes)
 
 The geometry-coherent model **replaces four existing guard mechanisms**:
 
-| Current Guard                            | Replacement                                       | Lines in tracking.go |
-| ---------------------------------------- | ------------------------------------------------- | -------------------- |
-| **Guard 2:** Aspect-ratio lock threshold | Subsumed by axis selection + shape classification | ~950-980             |
-| **Guard 3:** 90° jump rejection          | Subsumed by axis selection (lower residual wins)  | ~1000-1020           |
-| Dimension sync logic                     | Unified in ema_update()                           | ~1124-1141           |
-| HeadingSource enum complexity            | Simplified: aligned / swapped / rejected / motion | Various              |
+| Current Guard                            | Replacement                                       | Current location              |
+| ---------------------------------------- | ------------------------------------------------- | ----------------------------- |
+| **Guard 2:** Aspect-ratio lock threshold | Subsumed by axis selection + shape classification | `l5tracks/tracking_update.go` |
+| **Guard 3:** 90° jump rejection          | Subsumed by axis selection (lower residual wins)  | `l5tracks/tracking_update.go` |
+| Dimension sync logic                     | Unified in ema_update()                           | `l5tracks/tracking_update.go` |
+| HeadingSource enum complexity            | Simplified: aligned / swapped / rejected / motion | `l5tracks/tracking_config.go` |
 
 **Guard 1** (minimum point count) **remains** as a data-quality gate: it prevents OBB estimation when insufficient points are available.
 
@@ -444,19 +444,19 @@ Parameters should be validated and tuned through:
 
 ## 8. Implementation estimate
 
-| Component                              | Effort           | Files                                      |
-| -------------------------------------- | ---------------- | ------------------------------------------ |
-| Track geometry state struct            | **S** (half day) | `l5tracks/tracking.go`                     |
-| Axis selection + outlier gate          | **M** (1 day)    | `l5tracks/tracking.go`                     |
-| EMA update with shape classification   | **M** (1 day)    | `l5tracks/tracking.go`                     |
-| Heading-motion coupling (§3)           | **M** (1 day)    | `l5tracks/tracking.go`                     |
-| Uncertainty shrinkage logic            | **S** (half day) | `l5tracks/tracking.go`                     |
-| Configuration parameters               | **S** (half day) | `config/tuning.go`, `l5tracks/tracking.go` |
-| Remove replaced guards                 | **S** (half day) | `l5tracks/tracking.go`                     |
-| Unit tests (axis selection, residuals) | **M** (1 day)    | `l5tracks/tracking_test.go`                |
-| Integration tests (track stability)    | **M** (1 day)    | `l5tracks/tracking_coverage_test.go`       |
-| Documentation and logging              | **S** (half day) | Various                                    |
-| **Total**                              | **L (6-7 days)** |                                            |
+| Component                              | Effort           | Files                                                      |
+| -------------------------------------- | ---------------- | ---------------------------------------------------------- |
+| Track geometry state struct            | **S** (half day) | `l5tracks/tracking.go`                                     |
+| Axis selection + outlier gate          | **M** (1 day)    | `l5tracks/tracking_update.go`                              |
+| EMA update with shape classification   | **M** (1 day)    | `l5tracks/tracking_update.go`                              |
+| Heading-motion coupling (§3)           | **M** (1 day)    | `l5tracks/tracking_update.go`                              |
+| Uncertainty shrinkage logic            | **S** (half day) | `l5tracks/tracking_update.go`                              |
+| Configuration parameters               | **S** (half day) | `internal/config/tuning.go`, `l5tracks/tracking_config.go` |
+| Remove replaced guards                 | **S** (half day) | `l5tracks/tracking_update.go`                              |
+| Unit tests (axis selection, residuals) | **M** (1 day)    | `l5tracks/tracking_test.go`                                |
+| Integration tests (track stability)    | **M** (1 day)    | `l5tracks/tracking_coverage_test.go`                       |
+| Documentation and logging              | **S** (half day) | Various                                                    |
+| **Total**                              | **L (6-7 days)** |                                                            |
 
 ### 8.1 Dependencies
 
@@ -627,8 +627,12 @@ For ambiguous tracks, maintain multiple geometry hypotheses:
 ### 11.3 Internal references
 
 - `l4perception/obb.go`: Current PCA-based OBB estimation
-- `l5tracks/tracking.go`: Current guard mechanisms (lines 950-1141)
-- `l5tracks/kalman.go`: Existing Kalman filter for position/velocity
+- `l5tracks/tracking_update.go`: Current OBB guard mechanisms and update-time
+  heading/dimension logic
+- `l5tracks/tracking.go`: Existing track state, lifecycle, and Kalman-driven
+  association orchestration
+- `l5tracks/tracking_association.go`: Existing prediction, finite-state guard,
+  velocity clamp, and association helpers
 - [OBB heading stability review](20260222-obb-heading-stability-review.md): Current guard analysis
 - [Velocity-coherent foreground extraction](20260220-velocity-coherent-foreground-extraction.md): Future enhancement
 

--- a/data/maths/proposals/20260222-obb-heading-stability-review.md
+++ b/data/maths/proposals/20260222-obb-heading-stability-review.md
@@ -1,6 +1,6 @@
 # OBB heading stability review
 
-- **Status:** Implemented; Guard 3 (90° jump rejection) replaces canonical-axis normalisation. Fixes B, C, G applied. Fix D config-only. Fixes E/F skipped; superseded by geometry-coherent tracking (D-04).
+- **Status:** Implemented for the current guard stack; Guard 3 (90° jump rejection) replaces canonical-axis normalisation. Fixes B, C, and G are applied. Fix D remains config-only and unlanded in the shipped defaults (`0.25`); `0.15` / `0.10` are replay-validation candidates. Fixes E/F remain diagnostic follow-ups and should not revive proto, macOS visualiser, or L9 endpoint code before geometry-coherent tracking (D-04).
 - **Scope:** L4 clustering OBB, L5 tracking heading smoothing, visualiser rendering
 - **Related:**
 
@@ -146,12 +146,12 @@ renders all cluster boxes (ignoring association) would be valuable.
 | `l4perception/obb.go:103`     | `heading = atan2(evY, evX)`: raw PCA heading has 180° ambiguity     | Mitigated by velocity/displacement disambiguation |
 | `l4perception/obb.go:142–145` | `length` / `width` defined by principal axis: swaps when axis flips | Handled by 90° jump rejection (Guard 3)           |
 | `l5tracks/tracking.go`        | Velocity disambiguation only when speed > 0.5 m/s                   | Displacement fallback added (Fix C)               |
-| `l5tracks/tracking.go`        | Aspect-ratio lock threshold 0.25 may be too loose                   | Open (Fix D)                                      |
+| `l5tracks/tracking.go`        | Aspect-ratio lock threshold 0.25 may be too loose                   | Open (Fix D): validate 0.15 / 0.10 on replay data |
 | `l5tracks/tracking.go`        | 90° heading jumps from PCA axis swaps                               | **Fixed:** Guard 3 rejects 60°–120° jumps         |
 | `l5tracks/tracking.go`        | No heading-source diagnostic data                                   | **Fixed:** HeadingSource enum added (Fix G)       |
 | `l5tracks/tracking.go`        | Dimension averaging not axis-locked                                 | **Fixed:** per-frame cluster dims used (Fix B)    |
-| `MetalRenderer.swift`         | Track boxes use averaged dims with smoothed heading                 | Comment updated; Fix E pending                    |
-| `adapter.go`                  | Associated clusters not rendered (hinders debugging)                | Open (Fix F)                                      |
+| `MetalRenderer.swift`         | Track boxes use averaged dims with smoothed heading                 | Comment updated; Fix E not revived here           |
+| `adapter.go`                  | Associated clusters not rendered (hinders debugging)                | Open (Fix F); keep debug-only if revived          |
 
 ---
 
@@ -340,8 +340,12 @@ before tracking smoothing is applied.
 6. **Fix E** (renderer consistency): synchronise both renderers.
 7. **Fix F** (debug cluster rendering): optional, for ongoing tuning.
 
-Guard 3, fixes B, C, and G are implemented.
-Fix D is config-only. Fixes E and F are skipped: superseded by geometry-coherent tracking (D-04).
+Guard 3 and fixes B, C, and G are implemented.
+Fix D remains config-only, but the shipped default is still `0.25`; do not
+change it until replay validation supports a stricter threshold such as `0.15`
+or `0.10`. Fixes E and F are not revived here: keep them as diagnostic notes
+unless a separate implementation explicitly needs renderer parity or raw
+cluster OBB inspection before geometry-coherent tracking (D-04).
 
 ---
 
@@ -361,6 +365,9 @@ Fix D is config-only. Fixes E and F are skipped: superseded by geometry-coherent
 - Run existing `.vrlog` captures through the pipeline with and without fixes.
 - Measure heading jitter RMS (already tracked in
   `HeadingJitterSumSq`/`HeadingJitterCount`).
+- Record per-track `heading_source` and compare `obb_aspect_ratio_lock_threshold`
+  values (`0.25`, `0.15`, `0.10`) on the same replay pack before changing the
+  default.
 - Use heading-source debug rendering (Fix G) to identify which tracks have
   unstable heading sources.
 
@@ -391,9 +398,9 @@ The tracker already computes:
 
 ## 9. Open questions
 
-1. What is the optimal aspect-ratio lock threshold (Fix D)? The current 0.25
-   is likely too loose; 0.15 is proposed but should be validated against replay
-   data across multiple sites.
+1. What is the optimal aspect-ratio lock threshold (Fix D)? The current shipped
+   default remains `0.25`; compare `0.25`, `0.15`, and `0.10` against replay
+   data across multiple sites before landing a stricter default.
 
 2. Should the velocity-coherent extraction proposal (20260220) subsume Fix C?
    If per-point velocity vectors become available, they provide a stronger

--- a/data/maths/proposals/20260222-obb-heading-stability-review.md
+++ b/data/maths/proposals/20260222-obb-heading-stability-review.md
@@ -41,7 +41,7 @@ either direction along the principal axis, producing heading values that differ
 by π between frames for the same physical object. The result is a raw heading
 that may flip by 180° whenever the point distribution shifts slightly.
 
-The tracker (`l5tracks/tracking.go:1001–1024`) disambiguates using velocity:
+The tracker update path (`l5tracks/tracking_update.go`) disambiguates using velocity:
 
 ```text
 if speed > 0.5 m/s:
@@ -70,7 +70,7 @@ When the principal axis rotates by 90°, two things happen simultaneously:
    vice versa, because length is always defined as extent along the principal
    eigenvector.
 
-The aspect-ratio lock guard (`tracking.go:981–996`) exists to suppress heading
+The aspect-ratio lock guard (`l5tracks/tracking_update.go`) exists to suppress heading
 updates when the cluster is near-square:
 
 ```text
@@ -84,8 +84,8 @@ square that PCA can still swap axes between frames when a few points shift.
 ### 2.3 Dimension averaging without heading-locked axes
 
 `BoundingBoxLengthAvg` and `BoundingBoxWidthAvg` are running averages
-computed from per-frame OBB dimensions (`tracking.go:886–890`). Each frame,
-the track’s average length and width are updated incrementally:
+computed from per-frame OBB dimensions in `l5tracks/tracking_update.go`. Each
+frame, the track’s average length and width are updated incrementally:
 `avg = ((n-1)*avg + cluster_dimension) / n`.
 
 Because `cluster.BoundingBoxLength` is the OBB extent along the **current
@@ -100,7 +100,7 @@ each other (both approach the mean of the true length and true width). For a
 
 ### 2.4 Renderer dimension-heading mismatch
 
-The macOS renderer (`MetalRenderer.swift:460–512`) builds track box transforms
+The macOS renderer (`MetalRenderer.swift`) builds track box transforms
 using:
 
 - **Dimensions:** `bboxLength` × `bboxWidth` × `bboxHeight`
@@ -117,14 +117,14 @@ Result: the heading rotates but the box dimensions are averaged from mixed
 orientations, producing visible spinning as the heading changes but the box
 shape stays roughly square.
 
-The web renderer (`MapPane.svelte:582–601`) has a partial fix: it uses
+The web renderer (`MapPane.svelte`) has a partial fix: it uses
 **per-frame** OBB dimensions (`bbox.length` / `bbox.width`) rather than
 averaged dimensions, but still applies the smoothed OBB heading. This is
 better, but the per-frame dimensions still swap when PCA axes swap (§2.2).
 
 ### 2.5 Why unassociated (DBSCAN) cluster boxes are not visible
 
-The adapter (`adapter.go:212–259`) intentionally skips clusters that have been
+The L9 endpoint adapter (`l9endpoints/adapter.go`) intentionally skips clusters that have been
 associated with a track: if the cluster index has a non-empty association, the
 adapter continues to the next cluster (rendering it via the track instead).
 
@@ -145,13 +145,13 @@ renders all cluster boxes (ignoring association) would be valuable.
 | ----------------------------- | ------------------------------------------------------------------- | ------------------------------------------------- |
 | `l4perception/obb.go:103`     | `heading = atan2(evY, evX)`: raw PCA heading has 180° ambiguity     | Mitigated by velocity/displacement disambiguation |
 | `l4perception/obb.go:142–145` | `length` / `width` defined by principal axis: swaps when axis flips | Handled by 90° jump rejection (Guard 3)           |
-| `l5tracks/tracking.go`        | Velocity disambiguation only when speed > 0.5 m/s                   | Displacement fallback added (Fix C)               |
-| `l5tracks/tracking.go`        | Aspect-ratio lock threshold 0.25 may be too loose                   | Open (Fix D): validate 0.15 / 0.10 on replay data |
-| `l5tracks/tracking.go`        | 90° heading jumps from PCA axis swaps                               | **Fixed:** Guard 3 rejects 60°–120° jumps         |
-| `l5tracks/tracking.go`        | No heading-source diagnostic data                                   | **Fixed:** HeadingSource enum added (Fix G)       |
-| `l5tracks/tracking.go`        | Dimension averaging not axis-locked                                 | **Fixed:** per-frame cluster dims used (Fix B)    |
-| `MetalRenderer.swift`         | Track boxes use averaged dims with smoothed heading                 | Comment updated; Fix E not revived here           |
-| `adapter.go`                  | Associated clusters not rendered (hinders debugging)                | Open (Fix F); keep debug-only if revived          |
+| `l5tracks/tracking_update.go` | Velocity disambiguation only when speed > 0.5 m/s                   | Displacement fallback added (Fix C)               |
+| `l5tracks/tracking_update.go` | Aspect-ratio lock threshold 0.25 may be too loose                   | Open (Fix D): validate 0.15 / 0.10 on replay data |
+| `l5tracks/tracking_update.go` | 90° heading jumps from PCA axis swaps                               | **Fixed:** Guard 3 rejects 60°–120° jumps         |
+| `l5tracks/tracking_config.go` | Heading-source enum for diagnostic data                             | **Fixed:** `HeadingSource` enum added (Fix G)     |
+| `l5tracks/tracking_update.go` | Dimension averaging not axis-locked                                 | **Fixed:** per-frame cluster dims used (Fix B)    |
+| `MetalRenderer.swift`         | Track boxes use averaged dims with smoothed heading                 | Renderer now uses per-frame dimensions            |
+| `l9endpoints/adapter.go`      | Associated clusters not rendered (hinders debugging)                | Open (Fix F); keep debug-only if revived          |
 
 ---
 
@@ -210,12 +210,13 @@ contaminating foreground clusters), which would reduce PCA noise.
 **Problem:** Cannot determine which component is responsible for heading
 drift without additional diagnostic tooling.
 
-**Fix:** Added `HeadingSource` enum tracking through the full stack:
+**Fix:** Added `HeadingSource` enum tracking through the runtime data path:
 tracker → adapter → model → proto → gRPC → macOS renderer → web API.
 Values: `PCA` (0), `velocity` (1), `displacement` (2), `locked` (3).
 
-macOS visualiser gains `showHeadingSource` toggle that colours confirmed
-track boxes by heading source instead of lifecycle state:
+The macOS renderer has `showHeadingSource` colouring support for confirmed
+track boxes, but there is no current user-facing AppState/ContentView toggle
+wired to that renderer flag:
 
 - **Blue**: velocity-disambiguated (healthy)
 - **Yellow**: raw PCA (no disambiguation available)
@@ -315,7 +316,8 @@ OBBs regardless of association status. This would show:
 - Cyan boxes for all DBSCAN clusters
 - Green/yellow boxes for tracks (overlapping associated clusters)
 
-**Implementation:** The adapter already has `adaptClusters` (adapter.go:261–288)
+**Implementation:** The adapter already has `adaptClusters` in
+`internal/lidar/l9endpoints/adapter.go`
 which converts all clusters without filtering. Wire this to a debug flag.
 
 **Impact:** Enables visual debugging of OBB stability at the DBSCAN level,
@@ -373,8 +375,9 @@ cluster OBB inspection before geometry-coherent tracking (D-04).
 
 ### 7.3 Visual inspection
 
-- Enable `showHeadingSource` in macOS visualiser to see heading-source
-  colour coding (blue/yellow/orange/grey) on track boxes.
+- Use the macOS renderer's `showHeadingSource` support, or add a small UI toggle
+  for it, to see heading-source colour coding (blue/yellow/orange/grey) on
+  track boxes.
 - With Fix F enabled, compare raw DBSCAN OBBs against smoothed track OBBs
   in the macOS visualiser.
 - Confirm that cyan (cluster) boxes spin but green/yellow (track) boxes do

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -32,7 +32,9 @@ P1 → P2 → P4 → P3 confirmed — [MATHS.md](../data/maths/MATHS.md)
 
 ### D-06 — OBB heading fixes D/E/F
 
-Skip; P1 supersedes — [OBB heading review](../data/maths/proposals/20260222-obb-heading-stability-review.md)
+Keep as guard-stack maintenance only: validate Fix D thresholds before changing
+the shipped `0.25` default, leave Fixes E/F as debug-only follow-ups, and let
+P1 supersede further guard expansion — [OBB heading review](../data/maths/proposals/20260222-obb-heading-stability-review.md)
 
 ### D-07 — Track labelling UI (Phase 9)
 

--- a/docs/lidar/troubleshooting/garbage-tracks-checklist.md
+++ b/docs/lidar/troubleshooting/garbage-tracks-checklist.md
@@ -72,9 +72,9 @@ It combines the original review and checklist into one maintained source.
 - **Severity:** Medium; macOS visualiser only; **Fixed**
 - **Implemented behaviour:** Three guards added to `update()` in tracking.go:
   1. **Min-points threshold:** clusters with fewer than `MinPointsForPCA` (4) points skip heading update, retaining the previous smoothed heading.
-  2. **Aspect-ratio lock:** when `|length − width| / max(length, width) < OBBAspectRatioLockThreshold` (0.25), the heading is locked because the principal axis is ambiguous.
+  2. **Aspect-ratio lock:** when `|length − width| / max(length, width) < OBBAspectRatioLockThreshold` (currently `0.25`), the heading is locked because the principal axis is ambiguous. `0.15` and `0.10` are validation candidates, not shipped defaults.
   3. **Reduced smoothing α:** `OBBHeadingSmoothingAlpha` lowered from 0.15 to 0.08 for heavier EMA smoothing.
-     Per-frame OBB dimensions are always updated regardless of heading lock.
+     When the heading is locked, length and width are held to preserve axis consistency while height still updates.
 
 ### R1: next high-impact items
 

--- a/docs/lidar/troubleshooting/garbage-tracks-checklist.md
+++ b/docs/lidar/troubleshooting/garbage-tracks-checklist.md
@@ -70,7 +70,7 @@ It combines the original review and checklist into one maintained source.
 #### 8.4 OBB heading jitter in macOS view (PCA instability) ✅ done
 
 - **Severity:** Medium; macOS visualiser only; **Fixed**
-- **Implemented behaviour:** Three guards added to `update()` in tracking.go:
+- **Implemented behaviour:** Three guards added to `update()` in tracking_update.go:
   1. **Min-points threshold:** clusters with fewer than `MinPointsForPCA` (4) points skip heading update, retaining the previous smoothed heading.
   2. **Aspect-ratio lock:** when `|length − width| / max(length, width) < OBBAspectRatioLockThreshold` (currently `0.25`), the heading is locked because the principal axis is ambiguous. `0.15` and `0.10` are validation candidates, not shipped defaults.
   3. **Reduced smoothing α:** `OBBHeadingSmoothingAlpha` lowered from 0.15 to 0.08 for heavier EMA smoothing.

--- a/docs/lidar/troubleshooting/garbage-tracks-checklist.md
+++ b/docs/lidar/troubleshooting/garbage-tracks-checklist.md
@@ -12,14 +12,17 @@ It combines the original review and checklist into one maintained source.
 - Canonical reference files:
   - [tracking_pipeline.go](../../../internal/lidar/pipeline/tracking_pipeline.go)
   - [tracking.go](../../../internal/lidar/l5tracks/tracking.go)
+  - [tracking_association.go](../../../internal/lidar/l5tracks/tracking_association.go)
+  - [tracking_update.go](../../../internal/lidar/l5tracks/tracking_update.go)
   - [ground.go](../../../internal/lidar/l4perception/ground.go)
-  - [transform.go](../../../internal/lidar/l4perception/cluster.go)
+  - [cluster.go](../../../internal/lidar/l4perception/cluster.go)
   - [obb.go](../../../internal/lidar/l4perception/obb.go)
-  - [clustering.go](../../../internal/lidar/l4perception/cluster.go)
   - [track_store.go](../../../internal/lidar/storage/sqlite/track_store.go)
   - [frame_builder.go](../../../internal/lidar/l2frames/frame_builder.go)
   - [adapter.go](../../../internal/lidar/l9endpoints/adapter.go)
   - [track_api.go](../../../internal/lidar/server/track_api.go)
+  - [track_api_format.go](../../../internal/lidar/server/track_api_format.go)
+  - [lidar.ts](../../../web/src/lib/types/lidar.ts)
   - [MapPane.svelte](../../../web/src/lib/components/lidar/MapPane.svelte)
   - [api.ts](../../../web/src/lib/api.ts)
 
@@ -91,12 +94,12 @@ It combines the original review and checklist into one maintained source.
 #### 2.4 NaN/Inf guards after Kalman predict/update ✅ done
 
 - **Severity:** Medium; **Fixed**
-- **Implemented behaviour:** `isFiniteState()` helper checks X, Y, VX, VY and covariance diagonal for NaN/Inf. Called at the end of both `predict()` and `update()` in tracking.go. If any value is non-finite, the state is reset to defaults and the track is marked `TrackDeleted` to prevent corruption from propagating.
+- **Implemented behaviour:** `isFiniteState()` helper checks X, Y, VX, VY and covariance diagonal for NaN/Inf. Called at the end of `predict()` in `tracking_association.go` and `update()` in `tracking_update.go`. If any value is non-finite, the state is reset to defaults and the track is marked `TrackDeleted` to prevent corruption from propagating.
 
 #### 2.3 Velocity clamp on Kalman state ✅ done
 
 - **Severity:** Medium; **Fixed**
-- **Implemented behaviour:** `clampVelocity()` helper scales VX/VY proportionally so speed magnitude never exceeds `MaxReasonableSpeedMps` (30 m/s ≈ 108 km/h). Called at the end of both `predict()` and `update()` in tracking.go. This prevents teleport-like extrapolation from noisy Kalman updates.
+- **Implemented behaviour:** `clampVelocity()` helper scales VX/VY proportionally so speed magnitude never exceeds `MaxReasonableSpeedMps` (30 m/s ≈ 108 km/h). Called at the end of `predict()` in `tracking_association.go` and `update()` in `tracking_update.go`. This prevents teleport-like extrapolation from noisy Kalman updates.
 
 ### R2: medium-term hardening
 


### PR DESCRIPTION
## Summary
- Recover the useful OBB heading-stability guidance from old PR #397 as documentation only.
- Keep the shipped `obb_aspect_ratio_lock_threshold` default documented as `0.25`, with `0.15` / `0.10` framed as replay-validation candidates instead of landed behavior.
- Update the maintained maths, geometry, decision, troubleshooting, and config docs to reflect the current guard-stack state without reviving the old proto, macOS visualiser, L9 endpoint, or other code changes.

## Validation
- `python3 scripts/check-relative-links.py`
- `python3 scripts/check-backtick-paths.py`
- `pnpm --dir=web exec prettier --check ../config/CONFIG.md ../data/maths/MATHS.md ../data/maths/proposals/20260222-geometry-coherent-tracking.md ../data/maths/proposals/20260222-obb-heading-stability-review.md ../docs/DECISIONS.md ../docs/lidar/troubleshooting/garbage-tracks-checklist.md`
- `git diff --check`
- `make report-plan-hygiene` exits 0, but reports existing unrelated `docs/plans` gate/advisory items not touched by this branch.

Supersedes #397.