### PR TITLE
[py][docs] extract archive site inventory and classification investigations

### DIFF
--- a/docs/plans/archive-ingest-in-go-plan.md
+++ b/docs/plans/archive-ingest-in-go-plan.md
@@ -64,7 +64,7 @@ holds periods.
 | Area                    | Current state                                                                      | Severity | Release view                                                      |
 | ----------------------- | ---------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------- |
 | Per-file classification | Each file restarts the background model; its settling is reported as motion        | Blocker  | Classify per recording block, which `sessionMotionPass` does      |
-| Site truncation         | 3 of 23 sites end early where the motion gap exceeds the stitcher's 180 s bridge   | High     | Disappears once classification is continuous                      |
+| Site truncation         | 3 of 23 sites end early where a motion gap exceeds the stitcher's 180 s bridge      | High     | Two are the artefact; one is a real event the bridge cannot judge  |
 | Bridge constant         | 180 s recovers the expected site count; 300 s merges genuinely separate sites      | High     | A tuned constant with no principled value; delete it, not tune it |
 | Capture attribution     | `MotionPeriod` records times and frames, no captures; the JSON records none either | High     | Periods must name the captures they span                          |
 | Recording blocks        | A day is not one stream: 9/1 restarts at 16:29 after a 176 s gap, sequence resets  | Medium   | Session derivation must split there, and be verified to           |
@@ -81,6 +81,16 @@ a threshold compensating for an artefact rather than measuring anything.
 
 9/1, classified here as continuous streams, needed no stitching at all: six
 static stretches of 18 to 22 minutes, one per site.
+
+The three short sites separate along the same line. s13 (9/2 13:20) and s21 (9/3
+14:40) are truncated by motion gaps of 241 s and 221 s that each straddle a file
+boundary, and the part on the far side — 99 s and 50 s, beginning at the new
+file's first packet — is settling, not motion. Take it out and the real gaps are
+141 s and 171 s, inside the bridge. s16 (9/3 10:35) is different: its 202 s gap
+sits wholly inside one capture, well after that file's model had settled, so it
+is a real motion event mid-site. Continuous classification fixes the first two by
+construction. The third is a judgement no bridge constant can make, and is the
+case for `--min-captures` reporting rather than silently repairing.
 
 ## Design / approach
 
@@ -237,3 +247,5 @@ index.
 - [ ] The per-file `segments.json` on the drive stays as history; nothing reads it
 - [ ] Positions read from a photograph are accurate to a few hundred metres, and
       are a starting point for a survey rather than one
+- [ ] A real motion event mid-site still splits it; `--min-captures` reports the
+      short period rather than the classifier guessing the two halves are one

--- a/docs/plans/archive-ingest-in-go-plan.md
+++ b/docs/plans/archive-ingest-in-go-plan.md
@@ -66,6 +66,7 @@ holds periods.
 | Per-file classification | Each file restarts the background model; its settling is reported as motion        | Blocker  | Classify per recording block, which `sessionMotionPass` does      |
 | Site truncation         | 3 of 23 sites end early where a motion gap exceeds the stitcher's 180 s bridge      | High     | Two are the artefact; one is a real event the bridge cannot judge  |
 | Bridge constant         | 180 s recovers the expected site count; 300 s merges genuinely separate sites      | High     | A tuned constant with no principled value; delete it, not tune it |
+| Settling on long streams | A 27-capture stream misses a stop the per-file run finds, and lags the rest by ~4 min | High     | Re-derive the settling parameters for stream-length input          |
 | Capture attribution     | `MotionPeriod` records times and frames, no captures; the JSON records none either | High     | Periods must name the captures they span                          |
 | Recording blocks        | A day is not one stream: 9/1 restarts at 16:29 after a 176 s gap, sequence resets  | Medium   | Session derivation must split there, and be verified to           |
 | Validity                | Nothing asserts a site is plausible; a 12-minute "20-minute site" passes silently  | Medium   | A site spanning fewer than four captures is a defect, not a site  |
@@ -91,6 +92,23 @@ sits wholly inside one capture, well after that file's model had settled, so it
 is a real motion event mid-site. Continuous classification fixes the first two by
 construction. The third is a judgement no bridge constant can make, and is the
 case for `--min-captures` reporting rather than silently repairing.
+
+That expectation is only half borne out. Re-running 9/3's morning block as one
+27-capture stream does **not** reproduce the per-file result: it reports two
+static stretches where three were recorded, each beginning about four minutes
+after the per-file analysis puts the stop, and it swallows the 10:35 site
+(s16) into a single 68-minute opening motion. The operator's field map records a
+10:35 site, so the per-file analysis is closer to the truth there and the
+continuous run has a failure mode of its own — a long drive before the first
+stop leaves the background model matched to motion, and it is slow to re-converge
+when the platform finally stops.
+
+Continuous classification is still the right default, because it removes an
+artefact that is definitely wrong. But it is not a free win: the settling
+parameters were chosen for a per-file run and have not been re-derived for a
+two-hour stream. Workstream 2 must compare both classifications against the
+field map on all three days before the per-file output is retired, not assume
+the continuous one supersedes it.
 
 ## Design / approach
 
@@ -177,6 +195,8 @@ letting a short period pass as a location worth publishing.
    with `--min-captures` and `--json`.
 4. Verify session derivation splits on recorder restarts, with a test built from
    the 9/1 shape: sequence reset plus a gap of a few minutes.
+5. Compare continuous against per-file classification on all three days, scored
+   against the field map, before the per-file output stops being an input.
 
 **Milestone:** v0.6.0
 
@@ -236,6 +256,7 @@ index.
 - [ ] W2: `velocity lidar classify --root`, resumable (`M`)
 - [ ] W2: `velocity lidar sites --root --min-captures --json` (`M`)
 - [ ] W2: session derivation splits on recorder restart, with a 9/1-shaped test (`M`)
+- [ ] W2: score continuous against per-file on all three days before retiring per-file (`M`)
 - [ ] W3: static period references a site; tokens derive from the site pose (`M`)
 - [ ] W3: one-shot import of read positions into sites (`S`)
 - [ ] W3: scene publication reads the site pose (`S`)

--- a/docs/plans/archive-ingest-in-go-plan.md
+++ b/docs/plans/archive-ingest-in-go-plan.md
@@ -1,0 +1,239 @@
+# Archive ingest in Go (v0.6.x)
+
+- **Status:** Draft
+- **Layers:** LiDAR pipeline (L1, capture index), CLI, database
+- **Target:** v0.6.x; index the capture archive through the Go capture index, and delete the Python that currently stands between an operator and it
+- **Companion plans:** [lidar-scene-catalogue-publishing-plan](lidar-scene-catalogue-publishing-plan.md) owns archive-scale publishing; this plan owns getting the archive into the index correctly in the first place
+- **Canonical:** [geographic-indexing.md](../lidar/architecture/geographic-indexing.md) for S2 conventions
+
+## Motivation
+
+Indexing the 189 captures on `/Volumes/lidar/lidar/s2` currently runs through
+Python in `tools/s2-archive/`: a script to find recording blocks from filenames,
+a script to stitch motion/static segments back into sites, and a hand-maintained
+JSON of positions. None of that belongs in an operator's path. It exists because
+the segmentation on the drive was produced **per capture file**, and the
+segmenter's own help says not to do that:
+
+> Several `--pcap` flags analyse the captures as one continuous stream, which
+> keeps the background model settled across the file boundaries. Analysing each
+> file separately restarts that model and reports the settling as motion.
+
+The Python is a workaround for that mistake, not a missing feature. The Go
+pipeline already classifies a whole session as one joined stream, through the
+same engine the CLI uses. The work is to run the archive through what exists,
+close three gaps it has, and retire both the scripts and the per-file JSON on the
+drive.
+
+## Current state
+
+### Already in Go, and correct
+
+| Capability                           | Where                                                |
+| ------------------------------------ | ---------------------------------------------------- |
+| Scan a volume, detect drift          | `internal/lidar/capindex` (`Indexer.Refresh`)        |
+| Probe a capture's packet extent      | `capindex`, `CaptureStore.RecordProbe`               |
+| Derive sessions from probed extents  | `CaptureStore.DeriveSessions`                        |
+| Motion/static classification         | `internal/lidar/pcapsplit` (`Analyse`)               |
+| Classify a **session** as one stream | `server.sessionMotionPass` → `lidar_capture_periods` |
+| Join captures for replay             | `internal/lidar/capseq`, `readPCAPSequence`          |
+| Publish a scene from a recording     | `velocity scene export`                              |
+
+`sessionMotionPass` already sets `cfg.PCAPFiles` to every capture in the session,
+so the background model stays settled across file boundaries. It is the same
+`pcapsplit.Analyse` the CLI calls. The correct behaviour is present and wired to
+`POST /api/lidar/capture/motion-pass`.
+
+### In Python, and should not be
+
+| Script                                 | What it does                                              | Why it exists                                        |
+| -------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------- |
+| `tools/s2-archive/deployments.py`      | Groups captures into recording blocks from filenames      | Nothing exposed block structure                      |
+| `tools/s2-archive/build-site-index.py` | Stitches per-file segments into sites, attaches positions | The drive's segmentation is per file                 |
+| `tools/s2-archive/map-marks.json`      | Hand-read positions                                       | Legitimate input, but belongs with the site it names |
+
+### On the drive, and should be retired
+
+`s2/analysis/` holds 142 per-file `segments.json` — the artefact that forces the
+stitching. `s2/analysis-continuous/` holds the correct per-block output produced
+while writing this plan. Neither should be an input to anything once the index
+holds periods.
+
+## Findings
+
+| Area                    | Current state                                                                      | Severity | Release view                                                      |
+| ----------------------- | ---------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------- |
+| Per-file classification | Each file restarts the background model; its settling is reported as motion        | Blocker  | Classify per recording block, which `sessionMotionPass` does      |
+| Site truncation         | 3 of 23 sites end early where the motion gap exceeds the stitcher's 180 s bridge   | High     | Disappears once classification is continuous                      |
+| Bridge constant         | 180 s recovers the expected site count; 300 s merges genuinely separate sites      | High     | A tuned constant with no principled value; delete it, not tune it |
+| Capture attribution     | `MotionPeriod` records times and frames, no captures; the JSON records none either | High     | Periods must name the captures they span                          |
+| Recording blocks        | A day is not one stream: 9/1 restarts at 16:29 after a 176 s gap, sequence resets  | Medium   | Session derivation must split there, and be verified to           |
+| Validity                | Nothing asserts a site is plausible; a 12-minute "20-minute site" passes silently  | Medium   | A site spanning fewer than four captures is a defect, not a site  |
+| Position provenance     | Positions live in a JSON beside a script, not against the thing they locate        | Medium   | A period's site carries its own position, per the site model      |
+
+### Evidence for the classification defect
+
+Measured on this archive, per-file classification splits static stretches into
+fragments at file boundaries: 9/2 and 9/3 yield 17 and 19 static fragments where
+9 and 8 sites were recorded. Stitching across motion shorter than 180 s recovers
+exactly 9 and 8 — and 300 s merges two separate sites — which is the signature of
+a threshold compensating for an artefact rather than measuring anything.
+
+9/1, classified here as continuous streams, needed no stitching at all: six
+static stretches of 18 to 22 minutes, one per site.
+
+## Design / approach
+
+### 1. The archive goes through the capture index, not through scripts
+
+Scan and probe the volume, derive sessions, run a motion pass per session. Every
+step already exists and is reachable from `POST /api/lidar/capture/scan` and
+`POST /api/lidar/capture/motion-pass`. What is missing is a way to ask for the
+whole volume at once rather than session by session, and that is a CLI, not a new
+pipeline:
+
+```text
+velocity lidar index --root /Volumes/lidar/lidar/s2   # scan, probe, sessions
+velocity lidar classify --root /Volumes/lidar/lidar/s2 [--session ses-…]
+velocity lidar sites --root /Volumes/lidar/lidar/s2 [--min-captures 4]
+```
+
+`classify` is a loop over sessions calling the existing motion pass. `sites`
+reads `lidar_capture_periods` and prints or emits the static ones. No new
+classification code.
+
+### 2. A period names the captures it spans
+
+`MotionPeriod` carries `start_ns`/`end_ns` but no captures, so every consumer
+re-derives coverage from timestamps — the JSON exporter does not even try, and
+the Python got it wrong for a whole day. Store it once, at derivation, where the
+capture list is already in hand.
+
+The session's files and their probed extents are both known to
+`sessionMotionPass`, so coverage is an intersection, not a guess.
+
+### 3. Sessions split where recording stopped
+
+A recording block ends when the recorder is restarted: the sequence number resets
+and a real gap appears. On 9/1 that is a 176-second gap at 16:29 with the
+sequence going 45 → 1. Classification across that boundary is meaningless, and
+`velocity lidar pcap-split` already refuses it — correctly — as "captures do not
+form one continuous stream".
+
+Session derivation must produce the same split so the motion pass never assembles
+a stream the classifier will reject. This is a verification and, if needed, a
+correction to `DeriveSessions`, not new machinery.
+
+### 4. A site is a static period with a position
+
+The site model landed for replay cases (`lidar_sites`, canonical pose distinct
+from a case's sensor pose). A static period is the other thing that belongs at a
+site. Linking them gives the archive a position without a parallel store:
+
+- a static period may reference a site
+- a site keeps its canonical pose, label, and derived S2 tokens
+- `map-marks.json` becomes an import into that table, run once, not a file the
+  index reads every time
+
+### 5. Validity is checked, not assumed
+
+The recording protocol is roughly twenty minutes per site, which is four or more
+five-minute captures. A static period spanning fewer is either a truncation or
+something that was not a site. `sites --min-captures` reports them rather than
+letting a short period pass as a location worth publishing.
+
+## Scope
+
+### Workstream 1: Periods carry their captures
+
+**Steps:**
+
+1. Add capture coverage to `MotionPeriod` and its table, written at derivation.
+2. Populate it in `sessionMotionPass` from the session's capture list and probed
+   extents.
+3. Surface it on `GET /api/lidar/capture/periods` and in the Captures page.
+4. Backfill existing periods by intersection; there are few and they are cheap.
+
+**Milestone:** v0.6.0
+
+### Workstream 2: Whole-volume CLI
+
+**Steps:**
+
+1. `velocity lidar index --root` — scan, probe, derive sessions, report drift.
+2. `velocity lidar classify --root` — motion pass per session, resumable, skipping
+   sessions whose periods are current.
+3. `velocity lidar sites --root` — static periods with duration, captures and site,
+   with `--min-captures` and `--json`.
+4. Verify session derivation splits on recorder restarts, with a test built from
+   the 9/1 shape: sequence reset plus a gap of a few minutes.
+
+**Milestone:** v0.6.0
+
+### Workstream 3: Sites and positions
+
+**Steps:**
+
+1. Let a static period reference a site; derive S2 tokens from the site's pose.
+2. One-shot import of `map-marks.json` into sites, recording each position's
+   source and confidence rather than flattening it to a number.
+3. Scene publication reads the site's pose instead of `public_html/scene-sites.json`
+   carrying its own copy.
+
+**Milestone:** v0.6.1
+
+### Workstream 4: Retire the workarounds
+
+**Steps:**
+
+1. Delete `tools/s2-archive/*.py` once `sites --json` produces the same index.
+2. Stop reading `s2/analysis/`; the per-file JSON stays on the drive as history,
+   not as an input.
+3. Re-classify 9/2 and 9/3 as continuous streams so all three days are comparable.
+
+**Milestone:** v0.6.1
+
+## Phasing
+
+**Phase 0 — correctness.** Workstreams 1 and 2. The archive can be indexed end to
+end in Go, periods name their captures, and the short-site check runs. Done when
+`velocity lidar sites --min-captures 4` reports nothing on a freshly classified
+archive.
+
+**Phase 1 — position.** Workstream 3, once coordinates are worth storing.
+
+**Phase 2 — retirement.** Workstream 4, once Phase 0 output matches the committed
+index.
+
+## Risks
+
+| Risk                                                             | Likelihood | Impact | Mitigation                                                                          |
+| ---------------------------------------------------------------- | ---------- | ------ | ----------------------------------------------------------------------------------- |
+| Re-classifying changes site boundaries the published scenes used | Medium     | Medium | Scenes are derived; re-export is cheap and the VRLOGs are kept                      |
+| Session derivation splits differently from the classifier        | Medium     | High   | One test fixture drives both, built from the 9/1 restart                            |
+| Classifying the whole archive is slow                            | High       | Low    | Roughly 11 s per five-minute capture measured here; resumable and per session       |
+| Backfilled capture coverage disagrees with a future derivation   | Low        | Medium | Backfill by the same intersection the writer uses, not a separate code path         |
+| `map-marks.json` positions are treated as surveyed               | Medium     | High   | Import carries source and confidence; a read position is `operator`, not `surveyed` |
+
+## Checklist
+
+### Outstanding
+
+- [ ] W1: capture coverage on `MotionPeriod`, written at derivation (`M`)
+- [ ] W1: surface coverage on the periods endpoint and Captures page (`S`)
+- [ ] W1: backfill coverage for existing periods (`S`)
+- [ ] W2: `velocity lidar index --root` (`M`)
+- [ ] W2: `velocity lidar classify --root`, resumable (`M`)
+- [ ] W2: `velocity lidar sites --root --min-captures --json` (`M`)
+- [ ] W2: session derivation splits on recorder restart, with a 9/1-shaped test (`M`)
+- [ ] W3: static period references a site; tokens derive from the site pose (`M`)
+- [ ] W3: one-shot import of read positions into sites (`S`)
+- [ ] W3: scene publication reads the site pose (`S`)
+- [ ] W4: delete `tools/s2-archive/*.py` (`S`)
+- [ ] W4: re-classify 9/2 and 9/3 as continuous streams (`S`)
+
+### Accepted residuals (no action planned)
+
+- [ ] The per-file `segments.json` on the drive stays as history; nothing reads it
+- [ ] Positions read from a photograph are accurate to a few hundred metres, and
+      are a starting point for a survey rather than one

--- a/docs/plans/archive-ingest-in-go-plan.md
+++ b/docs/plans/archive-ingest-in-go-plan.md
@@ -5,6 +5,7 @@
 - **Target:** v0.6.x; index the capture archive through the Go capture index, and delete the Python that currently stands between an operator and it
 - **Companion plans:** [lidar-scene-catalogue-publishing-plan](lidar-scene-catalogue-publishing-plan.md) owns archive-scale publishing; this plan owns getting the archive into the index correctly in the first place
 - **Canonical:** [geographic-indexing.md](../lidar/architecture/geographic-indexing.md) for S2 conventions
+- **Open investigation:** [continuous-classification-brief](continuous-classification-brief.md) — why a continuous run reports more motion than a per-file one, which Workstream 2 waits on
 
 ## Motivation
 

--- a/docs/plans/archive-ingest-in-go-plan.md
+++ b/docs/plans/archive-ingest-in-go-plan.md
@@ -7,6 +7,8 @@
 - **Canonical:** [geographic-indexing.md](../lidar/architecture/geographic-indexing.md) for S2 conventions
 - **Open investigation:** [continuous-classification-brief](continuous-classification-brief.md) — why a continuous run reports more motion than a per-file one, which Workstream 2 waits on
 
+Implementation references below describe [PR #569](https://github.com/banshee-data/velocity.report/pull/569) and its local archive experiments. Capture indexing, session classification, and multi-file replay remain branch work until that PR merges. This investigation document does not announce those capabilities as shipped.
+
 ## Motivation
 
 Indexing the 189 captures on `/Volumes/lidar/lidar/s2` currently runs through
@@ -28,7 +30,7 @@ drive.
 
 ## Current state
 
-### Already in Go, and correct
+### Implemented on the Captures branch
 
 | Capability                           | Where                                                |
 | ------------------------------------ | ---------------------------------------------------- |
@@ -56,22 +58,22 @@ so the background model stays settled across file boundaries. It is the same
 ### On the drive, and should be retired
 
 `s2/analysis/` holds 142 per-file `segments.json` — the artefact that forces the
-stitching. `s2/analysis-continuous/` holds the correct per-block output produced
+stitching. `s2/analysis-continuous/` holds the experimental per-block output produced
 while writing this plan. Neither should be an input to anything once the index
 holds periods.
 
 ## Findings
 
-| Area                    | Current state                                                                      | Severity | Release view                                                      |
-| ----------------------- | ---------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------- |
-| Per-file classification | Each file restarts the background model; its settling is reported as motion        | Blocker  | Classify per recording block, which `sessionMotionPass` does      |
-| Site truncation         | 3 of 23 sites end early where a motion gap exceeds the stitcher's 180 s bridge      | High     | Two are the artefact; one is a real event the bridge cannot judge  |
-| Bridge constant         | 180 s recovers the expected site count; 300 s merges genuinely separate sites      | High     | A tuned constant with no principled value; delete it, not tune it |
-| Settling on long streams | A 27-capture stream misses a stop the per-file run finds, and lags the rest by ~4 min | High     | Re-derive the settling parameters for stream-length input          |
-| Capture attribution     | `MotionPeriod` records times and frames, no captures; the JSON records none either | High     | Periods must name the captures they span                          |
-| Recording blocks        | A day is not one stream: 9/1 restarts at 16:29 after a 176 s gap, sequence resets  | Medium   | Session derivation must split there, and be verified to           |
-| Validity                | Nothing asserts a site is plausible; a 12-minute "20-minute site" passes silently  | Medium   | A site spanning fewer than four captures is a defect, not a site  |
-| Position provenance     | Positions live in a JSON beside a script, not against the thing they locate        | Medium   | A period's site carries its own position, per the site model      |
+| Area                     | Current state                                                                         | Severity | Release view                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------- |
+| Per-file classification  | Each file restarts the background model; its settling is reported as motion           | Blocker  | Classify per recording block, which `sessionMotionPass` does      |
+| Site truncation          | 3 of 23 sites end early where a motion gap exceeds the stitcher's 180 s bridge        | High     | Two are the artefact; one is a real event the bridge cannot judge |
+| Bridge constant          | 180 s recovers the expected site count; 300 s merges genuinely separate sites         | High     | A tuned constant with no principled value; delete it, not tune it |
+| Settling on long streams | A 27-capture stream misses a stop the per-file run finds, and lags the rest by ~4 min | High     | Re-derive the settling parameters for stream-length input         |
+| Capture attribution      | `MotionPeriod` records times and frames, no captures; the JSON records none either    | High     | Periods must name the captures they span                          |
+| Recording blocks         | A day is not one stream: 9/1 restarts at 16:29 after a 176 s gap, sequence resets     | Medium   | Session derivation must split there, and be verified to           |
+| Validity                 | Nothing asserts a site is plausible; a 12-minute "20-minute site" passes silently     | Medium   | A site spanning fewer than four captures is a defect, not a site  |
+| Position provenance      | Positions live in a JSON beside a script, not against the thing they locate           | Medium   | A period's site carries its own position, per the site model      |
 
 ### Evidence for the classification defect
 

--- a/docs/plans/continuous-classification-brief.md
+++ b/docs/plans/continuous-classification-brief.md
@@ -5,6 +5,7 @@
 - **Parent plan:** [archive-ingest-in-go-plan](archive-ingest-in-go-plan.md), Workstream 2
 - **Blocks:** retiring the per-file `segments.json` on the archive volume
 - **Canonical:** [pcap-analysis-mode.md](../lidar/operations/pcap-analysis-mode.md) for how a capture is classified
+- **Companion:** [motion-static-parameter-tuning-plan](motion-static-parameter-tuning-plan.md) owns the parameters this brief keeps running into
 
 ## The question
 

--- a/docs/plans/continuous-classification-brief.md
+++ b/docs/plans/continuous-classification-brief.md
@@ -7,6 +7,8 @@
 - **Canonical:** [pcap-analysis-mode.md](../lidar/operations/pcap-analysis-mode.md) for how a capture is classified
 - **Companion:** [motion-static-parameter-tuning-plan](motion-static-parameter-tuning-plan.md) owns the parameters this brief keeps running into
 
+Implementation references below describe [PR #569](https://github.com/banshee-data/velocity.report/pull/569) and its local archive experiments. Capture indexing, session classification, and multi-file replay remain branch work until that PR merges. This investigation document does not announce those capabilities as shipped.
+
 ## The question
 
 Analysing a recording block as one continuous stream is supposed to be strictly
@@ -20,10 +22,10 @@ task is to find out why before the per-file output stops being an input.
 Same binary, same parameters — `--settling-sec 75 --motion-trigger-sec 5
 --max-motion-gap-sec 45 --min-segment-sec 10` — on two recording blocks:
 
-| Block                 | Captures | Static  | Opening motion | Sites found | Sites recorded |
-| --------------------- | -------- | ------- | -------------- | ----------- | -------------- |
-| 9/1 block0 (222 min)  | 45       | 55.0 %  | 10.6 min       | 6           | 6              |
-| 9/3 block0 (132 min)  | 27       | 25.5 %  | **68.4 min**   | 2           | 3              |
+| Block                | Captures | Static | Opening motion | Sites found | Sites recorded |
+| -------------------- | -------- | ------ | -------------- | ----------- | -------------- |
+| 9/1 block0 (222 min) | 45       | 55.0 % | 10.6 min       | 6           | 6              |
+| 9/3 block0 (132 min) | 27       | 25.5 % | **68.4 min**   | 2           | 3              |
 
 For comparison, the archive's own per-file analysis of whole days: 9/2 is 56.2 %
 static, 9/3 is 44.1 %. The protocol was the same on all three days — drive to a
@@ -112,14 +114,14 @@ It changes the config hash and nothing else.
 
 ## Where things are
 
-| Thing                          | Path                                                     |
-| ------------------------------ | -------------------------------------------------------- |
-| Classifier                     | `internal/lidar/pcapsplit`                               |
-| Background model               | `internal/lidar/l3grid`                                  |
-| Session-level caller           | `server.sessionMotionPass` (`capture_motion_pcap.go`)    |
-| Per-file analysis (the archive) | `/Volumes/lidar/lidar/s2/analysis/*/segments.json`       |
-| Continuous runs so far          | `/Volumes/lidar/lidar/s2/analysis-continuous/`           |
-| Site index and field marks      | `tools/s2-archive/`                                      |
+| Thing                           | Path                                                  |
+| ------------------------------- | ----------------------------------------------------- |
+| Classifier                      | `internal/lidar/pcapsplit`                            |
+| Background model                | `internal/lidar/l3grid`                               |
+| Session-level caller            | `server.sessionMotionPass` (`capture_motion_pcap.go`) |
+| Per-file analysis (the archive) | `/Volumes/lidar/lidar/s2/analysis/*/segments.json`    |
+| Continuous runs so far          | `/Volumes/lidar/lidar/s2/analysis-continuous/`        |
+| Site index and field marks      | `tools/s2-archive/`                                   |
 
 A 27-capture block takes about 20 minutes of wall clock to analyse, and a
 45-capture block about 32, so a parameter sweep is an afternoon rather than a

--- a/docs/plans/continuous-classification-brief.md
+++ b/docs/plans/continuous-classification-brief.md
@@ -1,0 +1,133 @@
+# Brief: why continuous classification reports more motion
+
+- **Status:** Open investigation, ready to hand over
+- **Layers:** LiDAR pipeline (L3 background model), `pcapsplit`
+- **Parent plan:** [archive-ingest-in-go-plan](archive-ingest-in-go-plan.md), Workstream 2
+- **Blocks:** retiring the per-file `segments.json` on the archive volume
+- **Canonical:** [pcap-analysis-mode.md](../lidar/operations/pcap-analysis-mode.md) for how a capture is classified
+
+## The question
+
+Analysing a recording block as one continuous stream is supposed to be strictly
+better than analysing its five-minute captures one at a time: the background
+model stays settled across file boundaries instead of restarting and reporting
+its own settling as motion. On 9/1 it is better. On 9/3 it is worse, and the
+task is to find out why before the per-file output stops being an input.
+
+## What was measured
+
+Same binary, same parameters — `--settling-sec 75 --motion-trigger-sec 5
+--max-motion-gap-sec 45 --min-segment-sec 10` — on two recording blocks:
+
+| Block                 | Captures | Static  | Opening motion | Sites found | Sites recorded |
+| --------------------- | -------- | ------- | -------------- | ----------- | -------------- |
+| 9/1 block0 (222 min)  | 45       | 55.0 %  | 10.6 min       | 6           | 6              |
+| 9/3 block0 (132 min)  | 27       | 25.5 %  | **68.4 min**   | 2           | 3              |
+
+For comparison, the archive's own per-file analysis of whole days: 9/2 is 56.2 %
+static, 9/3 is 44.1 %. The protocol was the same on all three days — drive to a
+junction, park about twenty minutes, drive on — so a block should come out near
+half static. 9/3 continuous comes out at a quarter.
+
+The three sites the per-file analysis finds in that window are 10:35 (11.7 min),
+11:05 (20.0 min) and 11:35 (20.0 min). Continuous finds two:
+
+```
+motion 10:00:51 → 11:09:15   68.4 min
+static 11:09:15 → 11:26:11   16.9 min
+motion 11:26:11 → 11:39:36   13.4 min
+static 11:39:36 → 11:56:24   16.8 min
+```
+
+Two things are wrong, and they may be one thing:
+
+1. **The 10:35 site is gone.** It is absorbed whole into the opening motion. The
+   operator's field map records a site there ("Van Ness near Market, Civic
+   Centre"), so its absence is a miss, not a correction.
+2. **Both surviving statics start about four minutes late** — 11:09 against
+   11:05, 11:39 against 11:35 — while their ends line up. The recording is not
+   losing time at the end of a stop, only at the beginning.
+
+That asymmetry is the strongest clue in the data. Whatever is wrong takes about
+four minutes to recover from after the platform stops, and on the 10:35 site —
+the shortest of the three — it apparently never recovers at all.
+
+## Hypotheses, most likely first
+
+**H1 — the background model is converging from a moving platform, and the
+recovery time scales with how long it drove first.** The model is built during
+settling and adapts thereafter. On 9/1 the block opens with 10.6 minutes of
+driving before the first stop; on 9/3 it drives about 34 minutes. A model that
+has absorbed 34 minutes of a changing scene has a wide variance estimate, so a
+stationary street's returns still read as foreground, and the frame keeps
+scoring as motion until the estimate tightens. This predicts the four-minute
+lag, predicts that a longer preceding drive makes the lag worse, and predicts
+that the shortest stop is the one that disappears. It is testable directly.
+
+**H2 — `--settling-sec 75` is the whole story.** The settling window is 75
+seconds from the first packet. On both blocks the platform is moving throughout
+it, so the model starts wrong in both cases; the difference would then be only
+how long it takes to recover. Distinguishing H2 from H1 matters: if it is H2 the
+fix is to settle on a detected stop rather than on a fixed prefix.
+
+**H3 — the parameters were tuned against five-minute files.** Every default here
+was chosen when a stream was 300 seconds long. `--max-motion-gap-sec 45` and
+`--motion-trigger-sec 5` may simply not mean the same thing over 132 minutes.
+
+**H4 — there was no 10:35 site and the per-file run invented it.** Against: the
+field map records one, and the per-file analysis gives it 11.7 minutes. Cheap to
+settle by looking at the frames, and worth settling first so the rest of the
+work is not chasing a phantom.
+
+**Excluded.** The tuning configuration is not the cause. The only parameter that
+differs between the good and bad runs is `pipeline.frame_budget_ms`, which is
+read solely by `lidarbench` for reporting and never reaches the pipeline
+(`internal/config/profile.go:155`, `internal/lidar/lidarbench/lidarbench.go:380`).
+It changes the config hash and nothing else.
+
+## Tasks
+
+1. **Settle H4 first.** Confirm from the frames that the platform is stationary
+   between 10:35 and 10:47 on 9/3. If it is not, stop: the per-file result is
+   the artefact and the rest of this brief is moot.
+2. **Instrument the decision.** `pcapsplit.Analyse` currently emits a verdict per
+   segment. Emit the per-frame statistic it decides on — foreground fraction, or
+   whatever the motion trigger reads — so a 68-minute motion segment can be read
+   as a curve. Without this the rest is guesswork.
+3. **Sweep the settling window** on 9/3 block0: 75 s (baseline), 300 s, 600 s,
+   and a run seeked to start at the first stop. If starting at a stop recovers
+   all three sites, H1/H2 are confirmed and the fix is a settling policy, not a
+   constant.
+4. **Measure the convergence lag against preceding motion duration** across every
+   block on all three days. If the lag is a function of the preceding drive, it
+   can be corrected for; if it is not, H1 is wrong.
+5. **Run 9/2 continuously.** It has never been run this way, and it is the third
+   data point that decides whether 9/1 or 9/3 is the outlier.
+6. **Score both classifications against the field map.** This is the acceptance
+   criterion for the parent plan: 23 recorded sites with known clock times in
+   `tools/s2-archive/site-index.json` and `map-marks.json`. A classification is
+   better when it recovers more of them at the right time, not when it produces
+   fewer segments.
+
+## Where things are
+
+| Thing                          | Path                                                     |
+| ------------------------------ | -------------------------------------------------------- |
+| Classifier                     | `internal/lidar/pcapsplit`                               |
+| Background model               | `internal/lidar/l3grid`                                  |
+| Session-level caller           | `server.sessionMotionPass` (`capture_motion_pcap.go`)    |
+| Per-file analysis (the archive) | `/Volumes/lidar/lidar/s2/analysis/*/segments.json`       |
+| Continuous runs so far          | `/Volumes/lidar/lidar/s2/analysis-continuous/`           |
+| Site index and field marks      | `tools/s2-archive/`                                      |
+
+A 27-capture block takes about 20 minutes of wall clock to analyse, and a
+45-capture block about 32, so a parameter sweep is an afternoon rather than a
+coffee break. Plan the sweep in one batch.
+
+## What a good answer looks like
+
+A statement of which classification is correct for the 9/3 morning and why,
+supported by the per-frame statistic rather than by segment counts; a settling
+policy that recovers all three sites without merging separate ones; and the
+scoring run from task 6 showing the chosen policy recovers at least as many of
+the 23 recorded sites as the per-file analysis does.

--- a/docs/plans/motion-static-parameter-tuning-plan.md
+++ b/docs/plans/motion-static-parameter-tuning-plan.md
@@ -5,6 +5,8 @@
 - **Canonical:** [pcap-analysis-mode.md](../lidar/operations/pcap-analysis-mode.md) for how a capture is classified
 - **Companion:** [static-sensor-nudge-tolerance-plan](static-sensor-nudge-tolerance-plan.md) is one case this must not break; [continuous-classification-brief](continuous-classification-brief.md) is the open question about stream length
 
+Implementation references below describe [PR #569](https://github.com/banshee-data/velocity.report/pull/569) and its local archive experiments. Capture indexing, session classification, and multi-file replay remain branch work until that PR merges. This investigation document does not announce those capabilities as shipped.
+
 ## Why
 
 Every parameter that decides what counts as motion was chosen against
@@ -12,11 +14,11 @@ five-minute files and has never been swept. The archive has since shown three
 separate ways they are wrong, and each was patched where it surfaced rather
 than at the parameter that caused it:
 
-| Symptom                                               | Patched as                                       |
-| ----------------------------------------------------- | ------------------------------------------------ |
-| Settling at a file boundary read as motion            | Discount motion starting at a capture's first packet |
-| A site split by a 241 s gap, 99 s of it settling      | The same discount, capped to gaps near the bridge |
-| A nudged tripod read as three stops and two drives    | Not patched; the junction is simply absent        |
+| Symptom                                            | Patched as                                           |
+| -------------------------------------------------- | ---------------------------------------------------- |
+| Settling at a file boundary read as motion         | Discount motion starting at a capture's first packet |
+| A site split by a 241 s gap, 99 s of it settling   | The same discount, capped to gaps near the bridge    |
+| A nudged tripod read as three stops and two drives | Not patched; the junction is simply absent           |
 
 Three patches on the same underlying fault. The bridge constant of 180 s is the
 clearest sign: it recovers exactly the expected site count on two days, and 300
@@ -25,17 +27,17 @@ compensating for something rather than measuring it.
 
 ## Parameters in scope
 
-| Parameter                       | Current | Chosen when                        |
-| ------------------------------- | ------- | ---------------------------------- |
-| `--settling-sec`                | 75      | Files were five minutes long       |
-| `--motion-trigger-sec`          | 5       | Untested against nudges            |
-| `--max-motion-gap-sec`          | 45      | Untested                           |
-| `--min-segment-sec`             | 10      | Untested                           |
-| `MIN_SITE` (index)              | 10 min  | Assumes a twenty-minute protocol   |
-| `BRIDGE_SECONDS` (index)        | 180     | Tuned to recover a known site count |
-| `DISCOUNT_CEILING` (index)      | 300     | Chosen to stop a discount cascade  |
-| `SafetyMarginMetres`            | —       | Background tolerance; never swept  |
-| `ClosenessSensitivityMultiplier` | —      | Background tolerance; never swept  |
+| Parameter                        | Current | Chosen when                         |
+| -------------------------------- | ------- | ----------------------------------- |
+| `--settling-sec`                 | 75      | Files were five minutes long        |
+| `--motion-trigger-sec`           | 5       | Untested against nudges             |
+| `--max-motion-gap-sec`           | 45      | Untested                            |
+| `--min-segment-sec`              | 10      | Untested                            |
+| `MIN_SITE` (index)               | 10 min  | Assumes a twenty-minute protocol    |
+| `BRIDGE_SECONDS` (index)         | 180     | Tuned to recover a known site count |
+| `DISCOUNT_CEILING` (index)       | 300     | Chosen to stop a discount cascade   |
+| `SafetyMarginMetres`             | —       | Background tolerance; never swept   |
+| `ClosenessSensitivityMultiplier` | —       | Background tolerance; never swept   |
 
 The last two are the interesting ones. Everything above them is a threshold on
 a decision the background model has already made; if the model tolerates a
@@ -71,9 +73,9 @@ this and best on segment count.
 
 ## Risks
 
-| Risk                                                        | Mitigation                                                     |
-| ----------------------------------------------------------- | -------------------------------------------------------------- |
-| Tuning to 24 marks overfits one campaign                     | Hold out a day; tune on two, score on the third                |
-| The marks are hand-read and a few minutes out                | Score on matching within tolerance, never on exact times       |
-| A sweep across the whole archive is expensive                | Sweep on one day, confirm the winner on all three              |
-| Better classification changes published scene boundaries     | Scenes are derived; re-export is cheap and the VRLOGs are kept |
+| Risk                                                     | Mitigation                                                     |
+| -------------------------------------------------------- | -------------------------------------------------------------- |
+| Tuning to 24 marks overfits one campaign                 | Hold out a day; tune on two, score on the third                |
+| The marks are hand-read and a few minutes out            | Score on matching within tolerance, never on exact times       |
+| A sweep across the whole archive is expensive            | Sweep on one day, confirm the winner on all three              |
+| Better classification changes published scene boundaries | Scenes are derived; re-export is cheap and the VRLOGs are kept |

--- a/docs/plans/motion-static-parameter-tuning-plan.md
+++ b/docs/plans/motion-static-parameter-tuning-plan.md
@@ -1,0 +1,79 @@
+# Motion/static parameter tuning (v0.6.x)
+
+- **Status:** Draft — investigation designed, not run
+- **Layers:** LiDAR pipeline (L3 background model), `pcapsplit`, capture index
+- **Canonical:** [pcap-analysis-mode.md](../lidar/operations/pcap-analysis-mode.md) for how a capture is classified
+- **Companion:** [static-sensor-nudge-tolerance-plan](static-sensor-nudge-tolerance-plan.md) is one case this must not break; [continuous-classification-brief](continuous-classification-brief.md) is the open question about stream length
+
+## Why
+
+Every parameter that decides what counts as motion was chosen against
+five-minute files and has never been swept. The archive has since shown three
+separate ways they are wrong, and each was patched where it surfaced rather
+than at the parameter that caused it:
+
+| Symptom                                               | Patched as                                       |
+| ----------------------------------------------------- | ------------------------------------------------ |
+| Settling at a file boundary read as motion            | Discount motion starting at a capture's first packet |
+| A site split by a 241 s gap, 99 s of it settling      | The same discount, capped to gaps near the bridge |
+| A nudged tripod read as three stops and two drives    | Not patched; the junction is simply absent        |
+
+Three patches on the same underlying fault. The bridge constant of 180 s is the
+clearest sign: it recovers exactly the expected site count on two days, and 300
+merges genuinely separate sites. A constant that has to be that precise is
+compensating for something rather than measuring it.
+
+## Parameters in scope
+
+| Parameter                       | Current | Chosen when                        |
+| ------------------------------- | ------- | ---------------------------------- |
+| `--settling-sec`                | 75      | Files were five minutes long       |
+| `--motion-trigger-sec`          | 5       | Untested against nudges            |
+| `--max-motion-gap-sec`          | 45      | Untested                           |
+| `--min-segment-sec`             | 10      | Untested                           |
+| `MIN_SITE` (index)              | 10 min  | Assumes a twenty-minute protocol   |
+| `BRIDGE_SECONDS` (index)        | 180     | Tuned to recover a known site count |
+| `DISCOUNT_CEILING` (index)      | 300     | Chosen to stop a discount cascade  |
+| `SafetyMarginMetres`            | —       | Background tolerance; never swept  |
+| `ClosenessSensitivityMultiplier` | —      | Background tolerance; never swept  |
+
+The last two are the interesting ones. Everything above them is a threshold on
+a decision the background model has already made; if the model tolerates a
+nudge, most of the thresholds stop mattering.
+
+## Method
+
+**Score against the field map, not against segment counts.** The archive has 24
+operator marks with times and named intersections, and 23 recorded sites. A
+parameter set is better when it recovers more of them at the right time. Fewer
+segments is not better; a single 8-hour "static" segment would score worst on
+this and best on segment count.
+
+1. Build the scoring harness first: given an index, report matched sites,
+   unmatched marks, and sites with no mark, per day. Nothing can be judged
+   without it.
+2. Establish the baseline: today's parameters against today's marks.
+3. Sweep the background tolerances alone, with every threshold fixed. If the
+   model can be made to tolerate a nudge without tolerating a drive, do that
+   and re-derive the thresholds afterwards rather than tuning them in parallel.
+4. Sweep the thresholds around whatever the model then needs.
+5. Retire the compensating constants. `BRIDGE_SECONDS` and `DISCOUNT_CEILING`
+   exist to undo the per-file artefact; if classification runs continuously and
+   the model tolerates nudges, both should be removable rather than retuned.
+
+## Acceptance
+
+- Every recorded day keeps or improves its matched-mark count
+- van Ness at Sacramento classifies as one site
+- No site over 30 minutes survives unexamined: `lombard-laguna` is 38.8 min and
+  is probably two stays that the current bridge merges
+- The 180 s bridge is gone, or has a stated physical meaning
+
+## Risks
+
+| Risk                                                        | Mitigation                                                     |
+| ----------------------------------------------------------- | -------------------------------------------------------------- |
+| Tuning to 24 marks overfits one campaign                     | Hold out a day; tune on two, score on the third                |
+| The marks are hand-read and a few minutes out                | Score on matching within tolerance, never on exact times       |
+| A sweep across the whole archive is expensive                | Sweep on one day, confirm the winner on all three              |
+| Better classification changes published scene boundaries     | Scenes are derived; re-export is cheap and the VRLOGs are kept |

--- a/docs/plans/static-sensor-nudge-tolerance-plan.md
+++ b/docs/plans/static-sensor-nudge-tolerance-plan.md
@@ -1,0 +1,86 @@
+# Static-sensor nudge tolerance (v0.6.x)
+
+- **Status:** Draft — test designed, not run
+- **Layers:** LiDAR pipeline (L3 background model), `pcapsplit`
+- **Canonical:** [pcap-analysis-mode.md](../lidar/operations/pcap-analysis-mode.md) for how a capture is classified
+- **Companion:** [motion-static-parameter-tuning-plan](motion-static-parameter-tuning-plan.md) owns the wider sweep
+
+## What happened
+
+The 9/2 recording at van Ness and Sacramento produced no site. The classifier
+read 21 minutes as five segments — 2.6 min static, 7.4 min motion, 2.4 static,
+2.6 motion, 1.1 static — so no static stretch reached the ten-minute minimum
+and the junction is absent from the archive.
+
+The operator's account is that the tripod stood on a camping chair and was
+nudged a few times. So the sensor did move, several times, by a small amount,
+and then stood still again. That is not the platform driving between junctions,
+which is what "motion" is supposed to mean here, and it is not noise either.
+
+This matters beyond one junction. A tripod that can be nudged is the normal
+case for this kind of survey, and a classifier that discards twenty minutes
+because the sensor was bumped three times will keep discarding them.
+
+## The question
+
+Three things, and they are separable:
+
+1. **Should a nudge read as motion at all?** A nudge displaces the sensor and
+   then stops. A drive displaces it continuously for minutes. The distinction
+   is available in the data — a nudge is a step, a drive is a ramp — and the
+   current trigger does not use it.
+2. **Would settling have recovered on its own?** After a nudge the background
+   model is wrong by the size of the nudge. Whether it re-converges depends on
+   how far the sensor moved against the model's tolerance. If it recovers in
+   seconds, the segment is static with a blip; if it does not, the model has to
+   be rebuilt and the segments really are separate.
+3. **Does the movement help or hurt the scene?** A few centimetres of parallax
+   between otherwise identical viewpoints is more information about the street,
+   not less. It may sharpen the background geometry, or it may smear it. Worth
+   knowing before deciding to suppress nudges rather than exploit them.
+
+## The test
+
+One capture set, five files, `s2_sf_4_202609021427*` through `*144716`, which
+is the whole van Ness episode: 14:27:14 to 14:48:23.
+
+### A. Characterise the nudges
+
+Measure, per frame, the rigid transform between the current point cloud and the
+first settled one. A nudge appears as a step in translation or rotation that
+holds; a drive appears as steady accumulation. Report how many nudges there
+were, how large each was in centimetres and degrees, and how long the pipeline
+took to settle after each.
+
+This is the measurement everything else depends on, and it does not exist yet.
+
+### B. Would settling have recovered?
+
+Replay the episode with the background model's tolerance swept:
+`SafetyMarginMetres`, `ClosenessSensitivityMultiplier`, and the post-settle
+alpha. For each, record whether the model re-converges after a nudge and how
+long it takes. The pass condition is one static segment covering the episode,
+not five.
+
+### C. Does the parallax help?
+
+Export the episode twice — once as-is, once with frames from the nudged
+intervals discarded — and compare the background point cloud: point count,
+surface coverage, and whether the street furniture reads as sharper or doubled.
+If the nudged version is better, a nudge is an asset and the pipeline should
+keep those frames rather than treating them as an interruption.
+
+## What a good answer looks like
+
+A stated tolerance — in centimetres and degrees — within which a displacement
+is a nudge rather than a move, with the van Ness episode classified as one
+static site under it, and no day in the archive gaining or losing a site as a
+side effect. Plus a yes or no on whether the parallax is worth keeping.
+
+## Risks
+
+| Risk                                                | Mitigation                                                        |
+| --------------------------------------------------- | ----------------------------------------------------------------- |
+| A tolerance wide enough for nudges hides real drift  | Score against the field map: no day may change its site count      |
+| Rigid-transform estimation is itself new machinery   | Only needed offline for the measurement, not in the live pipeline  |
+| The nudges are larger than assumed and nothing helps | Then the episode is genuinely three short stops; publish it as one and say so |

--- a/docs/plans/static-sensor-nudge-tolerance-plan.md
+++ b/docs/plans/static-sensor-nudge-tolerance-plan.md
@@ -5,6 +5,8 @@
 - **Canonical:** [pcap-analysis-mode.md](../lidar/operations/pcap-analysis-mode.md) for how a capture is classified
 - **Companion:** [motion-static-parameter-tuning-plan](motion-static-parameter-tuning-plan.md) owns the wider sweep
 
+Implementation references below describe [PR #569](https://github.com/banshee-data/velocity.report/pull/569) and its local archive experiments. Capture indexing, session classification, and multi-file replay remain branch work until that PR merges. This investigation document does not announce those capabilities as shipped.
+
 ## What happened
 
 The 9/2 recording at van Ness and Sacramento produced no site. The classifier
@@ -79,8 +81,8 @@ side effect. Plus a yes or no on whether the parallax is worth keeping.
 
 ## Risks
 
-| Risk                                                | Mitigation                                                        |
-| --------------------------------------------------- | ----------------------------------------------------------------- |
-| A tolerance wide enough for nudges hides real drift  | Score against the field map: no day may change its site count      |
-| Rigid-transform estimation is itself new machinery   | Only needed offline for the measurement, not in the live pipeline  |
+| Risk                                                 | Mitigation                                                                    |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------- |
+| A tolerance wide enough for nudges hides real drift  | Score against the field map: no day may change its site count                 |
+| Rigid-transform estimation is itself new machinery   | Only needed offline for the measurement, not in the live pipeline             |
 | The nudges are larger than assumed and nothing helps | Then the episode is genuinely three short stops; publish it as one and say so |

--- a/tools/s2-archive/README.md
+++ b/tools/s2-archive/README.md
@@ -16,6 +16,13 @@ everything else here produces or feeds it.
 | `build-site-index.py` | Stitches the segment analysis and attaches positions.              |
 | `deployments.py`      | Reconstructs recording blocks from capture filenames alone.        |
 
+The published scene map reads this index. Each scene export is joined to a site
+by the wall clock in its header and inherits that site's position, so a mark
+corrected here moves the marker, the cell and the token on `/scenes/` once
+`make render-scene-map` has run. A scene the archive does not cover, or whose
+map reading is known to be wrong, is positioned in
+`public_html/scene-overrides.json` instead, and the override wins.
+
 ## The two analyses, and why they differ
 
 `velocity lidar pcap-split` classifies a capture into motion and static

--- a/tools/s2-archive/README.md
+++ b/tools/s2-archive/README.md
@@ -1,0 +1,54 @@
+# S2 archive site index
+
+Every site the sensor was parked at on `/Volumes/lidar/lidar/s2`, across the
+three recording days, with the captures each one spans and an approximate
+position.
+
+A site is a **static** stretch: the car drove between junctions with the sensor
+running, so a day is one continuous recording and the sites are the stretches
+within it where the platform was stationary. `site-index.json` is the output;
+everything else here produces or feeds it.
+
+| File                  | What it is                                                         |
+| --------------------- | ------------------------------------------------------------------ |
+| `site-index.json`     | The index. Generated — edit `map-marks.json` and rebuild instead.  |
+| `map-marks.json`      | Positions read off the field map, by hand. The only input to edit. |
+| `build-site-index.py` | Stitches the segment analysis and attaches positions.              |
+| `deployments.py`      | Reconstructs recording blocks from capture filenames alone.        |
+
+## The two analyses, and why they differ
+
+`velocity lidar pcap-split` classifies a capture into motion and static
+segments. Its own help is explicit about how to run it:
+
+> Several `--pcap` flags analyse the captures as one continuous stream, which
+> keeps the background model settled across the file boundaries. Analysing each
+> file separately restarts that model and reports the settling as motion.
+
+The archive's original analysis under `s2/analysis/` was run per file, so every
+five-minute boundary interrupts a site: 9/2 and 9/3 arrive as 17 and 19
+fragments rather than 9 and 8 sites. `build-site-index.py` stitches those back
+together, bridging motion shorter than three minutes, which recovers exactly the
+expected counts — and no more, since bridging five minutes starts merging
+genuinely separate sites.
+
+9/1 had no analysis at all. It was re-analysed as continuous streams into
+`s2/analysis-continuous/`, one per recording block, and comes out clean: six
+static stretches of 18 to 22 minutes with no stitching needed. Rerunning 9/2 and
+9/3 the same way would remove the need to bridge them.
+
+## Positions are approximate
+
+`map-marks.json` holds positions read by eye from a photograph of a hand-marked
+paper map, matched to sites by day and clock time. They are neighbourhood-level:
+where a published scene gives an independent check, the map reading was about
+450 m out. Treat them as a starting point for a survey, not as one — which is
+why each carries a confidence and why a mark that could not be read leaves the
+position null rather than guessed.
+
+## Rebuild
+
+```bash
+python3 tools/s2-archive/build-site-index.py   # after editing map-marks.json
+python3 tools/s2-archive/deployments.py        # recording blocks from filenames
+```

--- a/tools/s2-archive/README.md
+++ b/tools/s2-archive/README.md
@@ -37,6 +37,19 @@ genuinely separate sites.
 static stretches of 18 to 22 minutes with no stitching needed. Rerunning 9/2 and
 9/3 the same way would remove the need to bridge them.
 
+## Which captures a site spans
+
+A per-file analysis names its one capture and nothing else. A continuous
+analysis reports the whole block as one stream: it lists every capture in
+`config.pcap_files` but attributes no segment to any of them, and its top-level
+`input_file` is only the first. Reading that field per segment credits a whole
+day to one capture, which is why 9/1 first came out as six single-capture
+sites. Consecutive captures abut, so each one covers the clock from its own
+start to the next one's, and a segment spans whichever of those it overlaps.
+
+A site is roughly twenty minutes, which is four or more five-minute captures.
+Fewer than four means the period was truncated, not that the site was short.
+
 ## Positions are approximate
 
 `map-marks.json` holds positions read by eye from a photograph of a hand-marked

--- a/tools/s2-archive/README.md
+++ b/tools/s2-archive/README.md
@@ -9,14 +9,15 @@ running, so a day is one continuous recording and the sites are the stretches
 within it where the platform was stationary. `site-index.json` is the output;
 everything else here produces or feeds it.
 
-| File                  | What it is                                                         |
-| --------------------- | ------------------------------------------------------------------ |
-| `site-index.json`     | The index. Generated — edit `map-marks.json` and rebuild instead.  |
-| `map-marks.json`      | Positions read off the field map, by hand. The only input to edit. |
-| `build-site-index.py` | Stitches the segment analysis and attaches positions.              |
-| `deployments.py`      | Reconstructs recording blocks from capture filenames alone.        |
+| File                  | What it is                                                               |
+| --------------------- | ------------------------------------------------------------------------ |
+| `site-index.json`     | The index. Generated — edit `map-marks.json` and rebuild instead.        |
+| `map-marks.json`      | Operator-named positions and optional orientation measurements.          |
+| `site-joins.json`     | Operator assertions that separated static fragments belong to one visit. |
+| `build-site-index.py` | Stitches the segment analysis and attaches positions.                    |
+| `deployments.py`      | Reconstructs recording blocks from capture filenames alone.              |
 
-The published scene map reads this index. Each scene export is joined to a site
+The scene catalogue being developed in [PR #569](https://github.com/banshee-data/velocity.report/pull/569) reads this index. Its map generator and `make render-scene-map` target are part of a later extraction, not this archive-tooling change. Each scene export is joined to a site
 by the wall clock in its header and inherits that site's position, so a mark
 corrected here moves the marker, the cell and the token on `/scenes/` once
 `make render-scene-map` has run. A scene the archive does not cover, or whose
@@ -26,7 +27,7 @@ map reading is known to be wrong, is positioned in
 ## The two analyses, and why they differ
 
 `velocity lidar pcap-split` classifies a capture into motion and static
-segments. Its own help is explicit about how to run it:
+segments. The multi-file CLI in [PR #569](https://github.com/banshee-data/velocity.report/pull/569) documents how to run a continuous analysis:
 
 > Several `--pcap` flags analyse the captures as one continuous stream, which
 > keeps the background model settled across the file boundaries. Analysing each
@@ -41,8 +42,7 @@ genuinely separate sites.
 
 9/1 had no analysis at all. It was re-analysed as continuous streams into
 `s2/analysis-continuous/`, one per recording block, and comes out clean: six
-static stretches of 18 to 22 minutes with no stitching needed. Rerunning 9/2 and
-9/3 the same way would remove the need to bridge them.
+static stretches of 18 to 22 minutes with no stitching needed. Continuous analysis is not yet a replacement for the per-file inputs: a 9/3 run misses a recorded stop and starts two others late. Keep both inputs while the [classification investigation](../../docs/plans/continuous-classification-brief.md) is open.
 
 ## Which captures a site spans
 
@@ -72,3 +72,9 @@ position null rather than guessed.
 python3 tools/s2-archive/build-site-index.py   # after editing map-marks.json
 python3 tools/s2-archive/deployments.py        # recording blocks from filenames
 ```
+
+## Rebuild inputs and publication state
+
+The scripts read the local archive at `/Volumes/lidar/lidar/s2`; the PCAPs and analysis JSON are not included in this PR. The committed index is an archive snapshot, not evidence that every linked recording is published on `main`. Its `published_as` fields record scene identifiers observed on the development branch. A rebuild on a checkout without those exports sets the corresponding fields to null.
+
+`build-site-index.py` reads both analysis trees, the field marks, the operator joins, and any locally available scene headers. It writes only `site-index.json`. `deployments.py` prints a filename-based grouping; its eleven-minute grouping threshold is not the production replay continuity policy. The publishing launcher remains with PR #569 because it requires the new multi-file replay API.

--- a/tools/s2-archive/build-site-index.py
+++ b/tools/s2-archive/build-site-index.py
@@ -114,12 +114,55 @@ def load(paths):
     return sorted(out, key=lambda s: s["start"])
 
 
+# A motion segment starting within this many seconds of its capture's first
+# packet is the background model settling, not the platform moving.
+SETTLING_TOLERANCE = 1.0
+
+# The largest raw gap a settling discount may be applied to. Beyond this the
+# gap is a drive, whatever the analysis restarts inside it.
+DISCOUNT_CEILING = 300.0
+
+
+def settling_artefact(segment):
+    """Is this 'motion' just a per-file analysis restarting its background model?
+
+    A per-file run rebuilds the model at every capture boundary and reports the
+    settling as motion. Such a segment always begins at its file's first packet;
+    real motion almost never does, because the platform does not start moving at
+    the exact instant a capture rolls over.
+    """
+    return segment["type"] == "motion" and segment["start_secs"] < SETTLING_TOLERANCE
+
+
+def real_gap_seconds(segments, first, second):
+    """The motion between two static stretches, discounting settling artefacts.
+
+    Bridging on the raw gap punishes a site for the analysis's own restarts. On
+    9/2 the stretch at 13:20 was cut from the one at 13:37 by 241 s of "motion",
+    99 s of which was the model settling at the start of capture 5. The real
+    gap is 141 s, inside the bridge, and the two are one site — which is what
+    the 35-minute recording of that junction shows.
+    """
+    total = (second["start"] - first["end"]).total_seconds()
+    # A drive between junctions crosses several capture boundaries and would
+    # collect a discount at each, so discounting is only allowed to rescue a
+    # gap that was nearly short enough already. Without this ceiling 9/2 fell
+    # from nine sites to five: the discounts added up and merged real drives.
+    if total > DISCOUNT_CEILING:
+        return total
+    for segment in segments:
+        if segment["start"] >= first["end"] and segment["end"] <= second["start"]:
+            if settling_artefact(segment):
+                total -= (segment["end"] - segment["start"]).total_seconds()
+    return total
+
+
 def stitch(segments, bridge):
     sites, current = [], None
     for segment in segments:
         if segment["type"] != "static":
             continue
-        if current and (segment["start"] - current["end"]).total_seconds() <= bridge:
+        if current and real_gap_seconds(segments, current, segment) <= bridge:
             current["end"] = segment["end"]
             current["parts"].append(segment)
         else:

--- a/tools/s2-archive/build-site-index.py
+++ b/tools/s2-archive/build-site-index.py
@@ -26,6 +26,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 PER_FILE = "/Volumes/lidar/lidar/s2/analysis"
 CONTINUOUS = "/Volumes/lidar/lidar/s2/analysis-continuous"
 MARKS = os.path.join(HERE, "map-marks.json")
+JOINS = os.path.join(HERE, "site-joins.json")
 OUT = os.path.join(HERE, "site-index.json")
 
 BRIDGE_SECONDS = 180
@@ -157,12 +158,48 @@ def real_gap_seconds(segments, first, second):
     return total
 
 
+def load_joins():
+    """Spans the operator says are one site, whatever the classifier read.
+
+    Only the person at the junction knows the tripod was nudged rather than
+    driven away. Until the background model can tell the difference, that
+    knowledge has to arrive from outside — see the nudge-tolerance plan.
+    """
+    if not os.path.exists(JOINS):
+        return []
+    with open(JOINS) as fh:
+        spans = json.load(fh).get("joins", [])
+    return [
+        (
+            datetime.fromisoformat(f"{span['day']}T{span['from']}"),
+            datetime.fromisoformat(f"{span['day']}T{span['to']}"),
+        )
+        for span in spans
+    ]
+
+
+JOIN_SPANS = load_joins()
+
+
+def asserted_together(first, second):
+    """Do both stretches fall inside one span the operator joined?"""
+    for start, end in JOIN_SPANS:
+        a = first["end"].replace(tzinfo=None)
+        b = second["start"].replace(tzinfo=None)
+        if start <= a <= end and start <= b <= end:
+            return True
+    return False
+
+
 def stitch(segments, bridge):
     sites, current = [], None
     for segment in segments:
         if segment["type"] != "static":
             continue
-        if current and real_gap_seconds(segments, current, segment) <= bridge:
+        if current and (
+            asserted_together(current, segment)
+            or real_gap_seconds(segments, current, segment) <= bridge
+        ):
             current["end"] = segment["end"]
             current["parts"].append(segment)
         else:
@@ -203,6 +240,9 @@ per_file = [
 later = stitch(load(per_file), BRIDGE_SECONDS)
 
 sites = sorted(day_one + later, key=lambda s: s["start"])
+
+# Every segment from both analyses, for attributing a site's captures below.
+all_segments = load(continuous) + load(per_file)
 
 with open(MARKS) as fh:
     marks = json.load(fh)["marks"]
@@ -269,7 +309,19 @@ for number, site in enumerate(sites, 1):
             "clock": site["start"].strftime("%I:%M").lstrip("0"),
             "minutes": round(minutes, 1),
             "fragments": len(site["parts"]),
-            "captures": sorted({c for p in site["parts"] for c in p["captures"]}),
+            # Every capture the site's span touches, not only the ones its
+            # static stretches fall in. A site joined across a nudge contains
+            # motion segments too, and their captures sit between the static
+            # ones — omit them and the replay is handed files 1, 4 and 5 and
+            # refuses them, correctly, as not one continuous stream.
+            "captures": sorted(
+                {
+                    capture
+                    for segment in all_segments
+                    if segment["start"] < site["end"] and site["start"] < segment["end"]
+                    for capture in segment["captures"]
+                }
+            ),
             "map_mark": mark["clock"] if mark else None,
             "where": mark["where"] if mark else None,
             "lat": mark["lat"] if mark else None,

--- a/tools/s2-archive/build-site-index.py
+++ b/tools/s2-archive/build-site-index.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Build the complete site index across all three recording days.
+
+Two sources, because the days were analysed differently. 9/1 was analysed here
+as one continuous stream, which keeps the background model settled across file
+boundaries and so reports each site as one segment. 9/2 and 9/3 carry the
+archive's original per-file analysis, where every file restarts that model and
+its settling is reported as motion — so their static periods arrive in pieces
+and are stitched back together, bridging motion shorter than BRIDGE_SECONDS.
+
+Positions come from the field map and are matched to a site by day and clock
+time. A site whose mark could not be read keeps no position rather than an
+invented one.
+"""
+
+import glob
+import json
+import os
+import re
+from datetime import datetime, timedelta, timezone
+
+# The captures are stamped in local Pacific daylight time.
+PACIFIC = timezone(timedelta(hours=-7))
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PER_FILE = "/Volumes/lidar/lidar/s2/analysis"
+CONTINUOUS = "/Volumes/lidar/lidar/s2/analysis-continuous"
+MARKS = os.path.join(HERE, "map-marks.json")
+OUT = os.path.join(HERE, "site-index.json")
+
+BRIDGE_SECONDS = 180
+MIN_SITE = timedelta(minutes=10)
+MARK_TOLERANCE = timedelta(minutes=25)
+
+
+def parse(ts):
+    return datetime.fromisoformat(
+        re.sub(r"\.(\d{6})\d+", lambda m: "." + m.group(1), ts)
+    )
+
+
+def load(paths):
+    out = []
+    for path in paths:
+        with open(path) as fh:
+            doc = json.load(fh)
+        source = os.path.basename(doc.get("input_file", ""))
+        for segment in doc.get("segments", []):
+            out.append(
+                {
+                    "type": segment["type"],
+                    "start": parse(segment["start_time"]),
+                    "end": parse(segment["end_time"]),
+                    "start_secs": segment["start_secs"],
+                    "end_secs": segment["end_secs"],
+                    "file": source,
+                }
+            )
+    return sorted(out, key=lambda s: s["start"])
+
+
+def stitch(segments, bridge):
+    sites, current = [], None
+    for segment in segments:
+        if segment["type"] != "static":
+            continue
+        if current and (segment["start"] - current["end"]).total_seconds() <= bridge:
+            current["end"] = segment["end"]
+            current["parts"].append(segment)
+        else:
+            current = {
+                "start": segment["start"],
+                "end": segment["end"],
+                "parts": [segment],
+            }
+            sites.append(current)
+    return [s for s in sites if (s["end"] - s["start"]) >= MIN_SITE]
+
+
+# 9/1: analysed here as one stream, so its segments already span the day.
+continuous = sorted(glob.glob(os.path.join(CONTINUOUS, "*", "*segments.json")))
+day_one = stitch(load(continuous), BRIDGE_SECONDS) if continuous else []
+
+# 9/2 and 9/3: the archive's per-file analysis, stitched back together.
+per_file = [
+    p
+    for p in sorted(glob.glob(os.path.join(PER_FILE, "*", "segments.json")))
+    if "_202609010" not in p and "_202609011" not in p
+]
+later = stitch(load(per_file), BRIDGE_SECONDS)
+
+sites = sorted(day_one + later, key=lambda s: s["start"])
+
+with open(MARKS) as fh:
+    marks = json.load(fh)["marks"]
+
+
+def match(site):
+    """The field mark closest in time on the same day, if one is close enough."""
+    day = site["start"].strftime("%Y-%m-%d")
+    best, best_gap = None, MARK_TOLERANCE
+    for mark in marks:
+        if mark["day"] != day:
+            continue
+        hour, minute = (int(v) for v in mark["clock"].split(":"))
+        # The sheet is a 12-hour clock and the driving day runs 09:00-17:00.
+        if hour < 8:
+            hour += 12
+        stamp = site["start"].replace(hour=hour, minute=minute, second=0, microsecond=0)
+        gap = abs(stamp - site["start"])
+        if gap < best_gap:
+            best, best_gap = mark, gap
+    return best, best_gap
+
+
+# Which sites already have a published scene, matched on the recording start
+# their export header carries.
+REPO = os.path.normpath(os.path.join(HERE, "..", ".."))
+published = {}
+for header in glob.glob(
+    os.path.join(REPO, "public_html/src/scenes/*/assets/part-000/header.json")
+):
+    with open(header) as fh:
+        start_ns = int(json.load(fh)["start_ns"])
+    scene = header.split(os.sep)[-4]
+    published[scene] = datetime.fromtimestamp(start_ns / 1e9, tz=PACIFIC)
+
+index, used = [], set()
+for number, site in enumerate(sites, 1):
+    mark, gap = match(site)
+    if mark and mark["clock"] in used:
+        mark = None
+    if mark:
+        used.add(mark["clock"])
+    minutes = (site["end"] - site["start"]).total_seconds() / 60
+    index.append(
+        {
+            "site": f"s{number:02d}",
+            "day": site["start"].strftime("%Y-%m-%d"),
+            "start": site["start"].isoformat(),
+            "clock": site["start"].strftime("%I:%M").lstrip("0"),
+            "minutes": round(minutes, 1),
+            "fragments": len(site["parts"]),
+            "captures": sorted({p["file"] for p in site["parts"] if p["file"]}),
+            "map_mark": mark["clock"] if mark else None,
+            "where": mark["where"] if mark else None,
+            "lat": mark["lat"] if mark else None,
+            "lon": mark["lon"] if mark else None,
+            "position_confidence": mark["confidence"] if mark else "no mark matched",
+            "published_as": next(
+                (
+                    scene
+                    for scene, start in published.items()
+                    if abs((start - site["start"]).total_seconds()) < 300
+                ),
+                None,
+            ),
+        }
+    )
+
+with open(OUT, "w") as fh:
+    json.dump(index, fh, indent=2)
+    fh.write("\n")
+
+by_day = {}
+for entry in index:
+    by_day.setdefault(entry["day"], []).append(entry)
+
+print(f"{len(index)} sites\n")
+print(f"{'site':5s} {'day':11s} {'clock':>6s} {'mins':>6s} {'mark':>6s}  position")
+for day in sorted(by_day):
+    for entry in by_day[day]:
+        pos = (
+            f"{entry['lat']:.4f}, {entry['lon']:.4f}  ({entry['position_confidence']})"
+            if entry["lat"] is not None
+            else f"—  ({entry['position_confidence']})"
+        )
+        print(
+            f"{entry['site']:5s} {entry['day']:11s} {entry['clock']:>6s} "
+            f"{entry['minutes']:6.1f} {str(entry['map_mark'] or '—'):>6s}  {pos}"
+        )
+    print()
+for day in sorted(by_day):
+    located = sum(1 for e in by_day[day] if e["lat"] is not None)
+    print(f"{day}: {len(by_day[day])} sites, {located} positioned")
+print(f"\nwritten: {OUT}")

--- a/tools/s2-archive/build-site-index.py
+++ b/tools/s2-archive/build-site-index.py
@@ -39,21 +39,76 @@ def parse(ts):
     )
 
 
+CAPTURE_NAME = re.compile(r"_(?P<stamp>\d{14})_\d+\.pcap$")
+
+
+def capture_spans(names, stream_end):
+    """When did each capture in a stream run.
+
+    A continuous analysis reports one stream, so its segments carry offsets into
+    that stream and no filename. Consecutive captures abut, so each one covers
+    the clock from its own start to the next one's — which is enough to say
+    which captures a segment crossed.
+    """
+    starts = []
+    for name in names:
+        match = CAPTURE_NAME.search(name)
+        if match:
+            starts.append(
+                (
+                    datetime.strptime(match["stamp"], "%Y%m%d%H%M%S"),
+                    os.path.basename(name),
+                )
+            )
+    starts.sort()
+    spans = []
+    for index, (start, name) in enumerate(starts):
+        end = starts[index + 1][0] if index + 1 < len(starts) else stream_end
+        spans.append((start, end, name))
+    return spans
+
+
 def load(paths):
     out = []
     for path in paths:
         with open(path) as fh:
             doc = json.load(fh)
+        segments = doc.get("segments", [])
+        if not segments:
+            continue
+
+        # A per-file analysis names its one capture; a continuous one lists them
+        # all in the config and attributes nothing, so the captures a segment
+        # crossed have to be recovered from the clock.
+        listed = doc.get("config", {}).get("pcap_files") or []
+        spans = []
+        if len(listed) > 1:
+            last_end = max(parse(s["end_time"]) for s in segments).replace(tzinfo=None)
+            spans = capture_spans(listed, last_end)
         source = os.path.basename(doc.get("input_file", ""))
-        for segment in doc.get("segments", []):
+
+        for segment in segments:
+            start, end = parse(segment["start_time"]), parse(segment["end_time"])
+            if spans:
+                naive_start, naive_end = start.replace(tzinfo=None), end.replace(
+                    tzinfo=None
+                )
+                covered = [
+                    name
+                    for (span_start, span_end, name) in spans
+                    if span_start < naive_end and naive_start < span_end
+                ]
+            else:
+                covered = [source] if source else []
             out.append(
                 {
                     "type": segment["type"],
-                    "start": parse(segment["start_time"]),
-                    "end": parse(segment["end_time"]),
+                    "start": start,
+                    "end": end,
                     "start_secs": segment["start_secs"],
                     "end_secs": segment["end_secs"],
                     "file": source,
+                    "captures": covered,
                 }
             )
     return sorted(out, key=lambda s: s["start"])
@@ -141,7 +196,7 @@ for number, site in enumerate(sites, 1):
             "clock": site["start"].strftime("%I:%M").lstrip("0"),
             "minutes": round(minutes, 1),
             "fragments": len(site["parts"]),
-            "captures": sorted({p["file"] for p in site["parts"] if p["file"]}),
+            "captures": sorted({c for p in site["parts"] for c in p["captures"]}),
             "map_mark": mark["clock"] if mark else None,
             "where": mark["where"] if mark else None,
             "lat": mark["lat"] if mark else None,

--- a/tools/s2-archive/build-site-index.py
+++ b/tools/s2-archive/build-site-index.py
@@ -132,15 +132,30 @@ def stitch(segments, bridge):
     return [s for s in sites if (s["end"] - s["start"]) >= MIN_SITE]
 
 
+# Which day a continuous analysis covers is read from its directory name, not
+# assumed. Both trees grow as blocks are re-analysed, and a day that has been
+# run continuously but is still read per file would otherwise be counted twice.
+CONTINUOUS_DAYS = {"20260901"}
+
+
+def day_of(path):
+    """The recording day a continuous analysis directory covers."""
+    return os.path.basename(os.path.dirname(path))[:8]
+
+
 # 9/1: analysed here as one stream, so its segments already span the day.
-continuous = sorted(glob.glob(os.path.join(CONTINUOUS, "*", "*segments.json")))
+continuous = [
+    p
+    for p in sorted(glob.glob(os.path.join(CONTINUOUS, "*", "*segments.json")))
+    if day_of(p) in CONTINUOUS_DAYS
+]
 day_one = stitch(load(continuous), BRIDGE_SECONDS) if continuous else []
 
-# 9/2 and 9/3: the archive's per-file analysis, stitched back together.
+# Every other day: the archive's per-file analysis, stitched back together.
 per_file = [
     p
     for p in sorted(glob.glob(os.path.join(PER_FILE, "*", "segments.json")))
-    if "_202609010" not in p and "_202609011" not in p
+    if not any(f"_{day}" in p for day in CONTINUOUS_DAYS)
 ]
 later = stitch(load(per_file), BRIDGE_SECONDS)
 

--- a/tools/s2-archive/build-site-index.py
+++ b/tools/s2-archive/build-site-index.py
@@ -238,13 +238,19 @@ for header in glob.glob(
     scene = header.split(os.sep)[-4]
     published[scene] = datetime.fromtimestamp(start_ns / 1e9, tz=PACIFIC)
 
+# A mark is claimed by one site. Keyed on the mark's id, which is unique;
+# keying it on the clock made two marks on different days collide, because the
+# sheet is a 12-hour clock and a run happens at the same hour most afternoons.
+# 9/2's 1:15 consumed the key and 9/3's 1:15 was refused, so a site recorded
+# two minutes from its mark was left unnamed and off the map. Two sites and two
+# marks were lost that way.
 index, used = [], set()
 for number, site in enumerate(sites, 1):
     mark, gap = match(site)
-    if mark and mark["clock"] in used:
+    if mark and mark["id"] in used:
         mark = None
     if mark:
-        used.add(mark["clock"])
+        used.add(mark["id"])
     minutes = (site["end"] - site["start"]).total_seconds() / 60
     index.append(
         {

--- a/tools/s2-archive/build-site-index.py
+++ b/tools/s2-archive/build-site-index.py
@@ -327,6 +327,9 @@ for number, site in enumerate(sites, 1):
             "lat": mark["lat"] if mark else None,
             "lon": mark["lon"] if mark else None,
             "position_confidence": mark["confidence"] if mark else "no mark matched",
+            # Optional operator-measured angles; see map-marks.json.
+            "grid_azimuth_deg": (mark or {}).get("grid_azimuth_deg"),
+            "north_azimuth_deg": (mark or {}).get("north_azimuth_deg"),
             "published_as": next(
                 (
                     scene

--- a/tools/s2-archive/build-site-index.py
+++ b/tools/s2-archive/build-site-index.py
@@ -205,6 +205,15 @@ for number, site in enumerate(sites, 1):
     minutes = (site["end"] - site["start"]).total_seconds() / 60
     index.append(
         {
+            # Identity comes from the field mark, which is named for the place
+            # and so survives a site being added, dropped or reclassified. The
+            # ordinal below is display order, not identity, and must not be
+            # used as a key: it shifts whenever the set changes.
+            "id": (
+                mark["id"]
+                if mark
+                else f"unrecognised-{site['start'].strftime('%m%d-%H%M')}"
+            ),
             "site": f"s{number:02d}",
             "day": site["start"].strftime("%Y-%m-%d"),
             "start": site["start"].isoformat(),

--- a/tools/s2-archive/deployments.py
+++ b/tools/s2-archive/deployments.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Reconstruct every deployment from capture filenames, analysed or not.
+
+Filenames carry the capture's start time, so the drive's own timeline can be
+rebuilt without reading a byte of packet data. A deployment is a run of
+captures that follow each other; a gap means the sensor was moved.
+"""
+
+import glob
+import json
+import os
+import re
+from datetime import datetime, timedelta
+
+PCAP_DIR = "/Volumes/lidar/lidar/s2"
+ANALYSIS = os.path.join(PCAP_DIR, "analysis")
+NAME = re.compile(r"^(?P<prefix>.+)_(?P<stamp>\d{14})_(?P<seq>\d+)\.pcap$")
+# Captures are five minutes apiece; a fresh site is minutes of driving away.
+DEPLOYMENT_GAP = timedelta(minutes=11)
+
+captures = []
+for path in sorted(glob.glob(os.path.join(PCAP_DIR, "*.pcap"))):
+    match = NAME.match(os.path.basename(path))
+    if not match:
+        continue
+    base = os.path.basename(path)[:-5]
+    captures.append(
+        {
+            "base": base,
+            "prefix": match["prefix"],
+            "start": datetime.strptime(match["stamp"], "%Y%m%d%H%M%S"),
+            "analysed": os.path.isdir(os.path.join(ANALYSIS, base)),
+        }
+    )
+captures.sort(key=lambda c: c["start"])
+
+deployments = []
+for capture in captures:
+    if deployments and capture["start"] - deployments[-1]["last"] <= DEPLOYMENT_GAP:
+        deployments[-1]["captures"].append(capture)
+        deployments[-1]["last"] = capture["start"]
+    else:
+        deployments.append(
+            {"captures": [capture], "last": capture["start"], "start": capture["start"]}
+        )
+
+
+# Static minutes each deployment's analysis reports, where it has any.
+def static_minutes(deployment):
+    total = 0.0
+    for capture in deployment["captures"]:
+        path = os.path.join(ANALYSIS, capture["base"], "segments.json")
+        if not os.path.exists(path):
+            return None
+        with open(path) as fh:
+            for segment in json.load(fh).get("segments", []):
+                if segment["type"] == "static":
+                    total += segment["duration_secs"]
+    return total / 60
+
+
+print(f"{len(captures)} captures in {len(deployments)} deployments\n")
+print(f"{'start':17s} {'clock':>7s} {'caps':>4s} {'span':>7s} {'static':>8s}  prefix")
+by_day = {}
+for deployment in deployments:
+    span = (deployment["last"] - deployment["start"]).total_seconds() / 60 + 5
+    static = static_minutes(deployment)
+    day = deployment["start"].strftime("%Y-%m-%d")
+    by_day.setdefault(day, []).append(deployment)
+    clock = deployment["start"].strftime("%I:%M").lstrip("0")
+    shown = f"{static:6.1f}m" if static is not None else "  none "
+    flag = "" if static is not None else "  <- not analysed"
+    print(
+        f"{deployment['start']:%Y-%m-%d %H:%M}  {clock:>7s} "
+        f"{len(deployment['captures']):4d} {span:6.1f}m {shown:>8s}  "
+        f"{deployment['captures'][0]['prefix']}{flag}"
+    )
+
+print()
+for day in sorted(by_day):
+    print(f"{day}: {len(by_day[day])} deployments")

--- a/tools/s2-archive/map-marks.json
+++ b/tools/s2-archive/map-marks.json
@@ -10,10 +10,17 @@
     "Day is inferred from the highlighted region and confirmed by the recording",
     "window: purple marks are all afternoon and 9/1 recorded 12:48-16:41; green",
     "spans the morning and 9/2 recorded from 09:14; the eastern marks match the",
-    "times detected on 9/3 almost exactly."
+    "times detected on 9/3 almost exactly.",
+    "",
+    "Each mark carries a stable id, slugged from the intersection name. That id",
+    "is the site's identity everywhere downstream: the site index, the scene",
+    "pages and their URLs. It is stable because it is derived from the place,",
+    "unlike the positional s01..s23 keys it replaces, which shifted whenever a",
+    "site was added or reclassified."
   ],
   "marks": [
     {
+      "id": "lombard-broderick",
       "day": "2026-09-02",
       "clock": "9:37",
       "where": "Lombard at Broderick",
@@ -22,6 +29,7 @@
       "confidence": "high"
     },
     {
+      "id": "marina-broderick",
       "day": "2026-09-02",
       "clock": "10:00",
       "where": "Marina Boulevard at Broderick",
@@ -30,6 +38,7 @@
       "confidence": "medium"
     },
     {
+      "id": "marina-fillmore",
       "day": "2026-09-02",
       "clock": "10:28",
       "where": "Marina Boulevard near Fillmore",
@@ -38,6 +47,7 @@
       "confidence": "medium"
     },
     {
+      "id": "union-van-ness",
       "day": "2026-09-02",
       "clock": "10:55",
       "where": "Union Street near Van Ness",
@@ -46,6 +56,7 @@
       "confidence": "medium"
     },
     {
+      "id": "fisherman-s-wharf",
       "day": "2026-09-02",
       "clock": "11:50",
       "where": "Fisherman's Wharf, Jefferson Street near Hyde",
@@ -54,6 +65,7 @@
       "confidence": "medium"
     },
     {
+      "id": "bay-embarcadero",
       "day": "2026-09-02",
       "clock": "12:36",
       "where": "Bay Street towards the Embarcadero",
@@ -62,6 +74,7 @@
       "confidence": "medium"
     },
     {
+      "id": "broadway-telegraph-hill",
       "day": "2026-09-02",
       "clock": "1:15",
       "where": "Broadway below Telegraph Hill, near Sansome",
@@ -70,6 +83,7 @@
       "confidence": "medium"
     },
     {
+      "id": "nob-hill-chinatown",
       "day": "2026-09-02",
       "clock": "3:25",
       "where": "Nob Hill / Chinatown edge",
@@ -78,6 +92,7 @@
       "confidence": "unread"
     },
     {
+      "id": "van-ness-market",
       "day": "2026-09-03",
       "clock": "10:35",
       "where": "Van Ness near Market, Civic Center",
@@ -86,6 +101,7 @@
       "confidence": "medium"
     },
     {
+      "id": "geary-larkin",
       "day": "2026-09-03",
       "clock": "11:00",
       "where": "Geary near Larkin",
@@ -94,6 +110,7 @@
       "confidence": "low"
     },
     {
+      "id": "bush-kearny",
       "day": "2026-09-03",
       "clock": "11:35",
       "where": "Bush Street near Kearny",
@@ -102,6 +119,7 @@
       "confidence": "medium"
     },
     {
+      "id": "front-davis-broadway",
       "day": "2026-09-03",
       "clock": "1:15",
       "where": "Front / Davis near Broadway, north waterfront",
@@ -110,6 +128,7 @@
       "confidence": "medium"
     },
     {
+      "id": "financial-district-battery",
       "day": "2026-09-03",
       "clock": "2:07",
       "where": "Financial District, Battery near Pine",
@@ -118,6 +137,7 @@
       "confidence": "medium"
     },
     {
+      "id": "rincon-hill-folsom",
       "day": "2026-09-03",
       "clock": "2:40",
       "where": "Rincon Hill, Folsom near Beale",
@@ -126,6 +146,7 @@
       "confidence": "medium"
     },
     {
+      "id": "soma-folsom-2nd",
       "day": "2026-09-03",
       "clock": "3:20",
       "where": "SoMa, Folsom near 2nd",
@@ -134,6 +155,7 @@
       "confidence": "medium"
     },
     {
+      "id": "soma-mission-8th",
       "day": "2026-09-03",
       "clock": "3:45",
       "where": "SoMa, Mission near 8th",
@@ -142,6 +164,7 @@
       "confidence": "medium"
     },
     {
+      "id": "ashbury-downey",
       "day": "2026-09-01",
       "clock": "12:35",
       "where": "Ashbury at Downey",
@@ -151,6 +174,7 @@
       "note": "Named by the operator, not read from the map. The static period detected for this site begins 12:58:38; recording started 12:48, so 12:35 is likely arrival rather than the start of the stationary stretch \u2014 every other 9/1 mark sits within four minutes of its detected start."
     },
     {
+      "id": "haight-divisadero",
       "day": "2026-09-01",
       "clock": "12:55",
       "where": "Haight by Divisadero",
@@ -159,6 +183,7 @@
       "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
+      "id": "pierce-haight",
       "day": "2026-09-01",
       "clock": "1:25",
       "where": "Pierce at Haight",
@@ -167,6 +192,7 @@
       "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
+      "id": "fulton-divisadero",
       "day": "2026-09-01",
       "clock": "1:55",
       "where": "Fulton at Divisadero",
@@ -175,6 +201,7 @@
       "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
+      "id": "california-leon-baker",
       "day": "2026-09-01",
       "clock": "2:30",
       "where": "California between Leon and Baker",
@@ -183,6 +210,7 @@
       "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
+      "id": "broadway-gough",
       "day": "2026-09-01",
       "clock": "3:05",
       "where": "Broadway at Gough",
@@ -191,6 +219,7 @@
       "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
+      "id": "laguna-eddy",
       "day": "2026-09-01",
       "clock": "3:40",
       "where": "Laguna at Eddy",

--- a/tools/s2-archive/map-marks.json
+++ b/tools/s2-archive/map-marks.json
@@ -1,0 +1,193 @@
+{
+  "comment": [
+    "Positions read by eye from the field map photograph, by locating each X",
+    "against the street labels printed around it. These are approximate: the",
+    "paper is photographed at an angle and a mark covers a couple of blocks, so",
+    "treat each as the neighbourhood rather than the junction. Confidence says",
+    "how much street context was legible around the mark, not how close the",
+    "reading is to a survey.",
+    "",
+    "Day is inferred from the highlighted region and confirmed by the recording",
+    "window: purple marks are all afternoon and 9/1 recorded 12:48-16:41; green",
+    "spans the morning and 9/2 recorded from 09:14; the eastern marks match the",
+    "times detected on 9/3 almost exactly."
+  ],
+  "marks": [
+    {
+      "day": "2026-09-02",
+      "clock": "9:37",
+      "where": "Cow Hollow, Union Street west of Fillmore",
+      "lat": 37.7975,
+      "lon": -122.436,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-02",
+      "clock": "10:00",
+      "where": "Marina Boulevard, west end near Baker",
+      "lat": 37.8055,
+      "lon": -122.4445,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-02",
+      "clock": "10:28",
+      "where": "Marina Boulevard near Fillmore",
+      "lat": 37.8065,
+      "lon": -122.436,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-02",
+      "clock": "10:55",
+      "where": "Union Street near Van Ness",
+      "lat": 37.7985,
+      "lon": -122.424,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-02",
+      "clock": "11:50",
+      "where": "Fisherman's Wharf, Jefferson Street near Hyde",
+      "lat": 37.807,
+      "lon": -122.42,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-02",
+      "clock": "12:36",
+      "where": "Bay Street towards the Embarcadero",
+      "lat": 37.8055,
+      "lon": -122.41,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-02",
+      "clock": "1:15",
+      "where": "Broadway below Telegraph Hill, near Sansome",
+      "lat": 37.798,
+      "lon": -122.402,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-01",
+      "clock": "3:05",
+      "where": "near the green/purple boundary; assigned to 9/1 on time, not position",
+      "lat": null,
+      "lon": null,
+      "confidence": "low (day inferred from time, mark sits on the region edge)"
+    },
+    {
+      "day": "2026-09-02",
+      "clock": "3:25",
+      "where": "Nob Hill / Chinatown edge",
+      "lat": null,
+      "lon": null,
+      "confidence": "unread"
+    },
+    {
+      "day": "2026-09-03",
+      "clock": "10:35",
+      "where": "Van Ness near Market, Civic Center",
+      "lat": 37.7755,
+      "lon": -122.419,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-03",
+      "clock": "11:00",
+      "where": "Geary near Larkin",
+      "lat": 37.786,
+      "lon": -122.4165,
+      "confidence": "low"
+    },
+    {
+      "day": "2026-09-03",
+      "clock": "11:35",
+      "where": "Bush Street near Kearny",
+      "lat": 37.791,
+      "lon": -122.4045,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-03",
+      "clock": "1:15",
+      "where": "Front / Davis near Broadway, north waterfront",
+      "lat": 37.7975,
+      "lon": -122.3985,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-03",
+      "clock": "2:07",
+      "where": "Financial District, Battery near Pine",
+      "lat": 37.793,
+      "lon": -122.4,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-03",
+      "clock": "2:40",
+      "where": "Rincon Hill, Folsom near Beale",
+      "lat": 37.789,
+      "lon": -122.3915,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-03",
+      "clock": "3:20",
+      "where": "SoMa, Folsom near 2nd",
+      "lat": 37.7855,
+      "lon": -122.397,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-03",
+      "clock": "3:45",
+      "where": "SoMa, Mission near 8th",
+      "lat": 37.779,
+      "lon": -122.413,
+      "confidence": "medium"
+    },
+    {
+      "day": "2026-09-01",
+      "clock": "12:55",
+      "where": "Haight / Divisadero",
+      "lat": 37.7715,
+      "lon": -122.4375,
+      "confidence": "low"
+    },
+    {
+      "day": "2026-09-01",
+      "clock": "1:25",
+      "where": "Market near Church / Duboce",
+      "lat": 37.769,
+      "lon": -122.429,
+      "confidence": "low"
+    },
+    {
+      "day": "2026-09-01",
+      "clock": "1:55",
+      "where": "NoPa, Fell / Oak near Divisadero",
+      "lat": 37.774,
+      "lon": -122.4375,
+      "confidence": "low"
+    },
+    {
+      "day": "2026-09-01",
+      "clock": "2:30",
+      "where": "Laurel Heights / Presidio Heights, California St",
+      "lat": 37.786,
+      "lon": -122.447,
+      "confidence": "low"
+    },
+    {
+      "day": "2026-09-01",
+      "clock": "3:40",
+      "where": "Western Addition, Golden Gate Avenue",
+      "lat": 37.779,
+      "lon": -122.43,
+      "confidence": "low"
+    }
+  ]
+}

--- a/tools/s2-archive/map-marks.json
+++ b/tools/s2-archive/map-marks.json
@@ -20,6 +20,70 @@
   ],
   "marks": [
     {
+      "id": "ashbury-downey",
+      "day": "2026-09-01",
+      "clock": "12:35",
+      "where": "Ashbury at Downey",
+      "lat": 37.769,
+      "lon": -122.445,
+      "confidence": "operator-named intersection; coordinate approximate to the block",
+      "note": "Named by the operator, not read from the map. The static period detected for this site begins 12:58:38; recording started 12:48, so 12:35 is likely arrival rather than the start of the stationary stretch \u2014 every other 9/1 mark sits within four minutes of its detected start."
+    },
+    {
+      "id": "haight-divisadero",
+      "day": "2026-09-01",
+      "clock": "12:55",
+      "where": "Haight at Divisadero",
+      "lat": 37.7712,
+      "lon": -122.4372,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
+    },
+    {
+      "id": "pierce-haight",
+      "day": "2026-09-01",
+      "clock": "1:25",
+      "where": "Pierce at Haight",
+      "lat": 37.7718,
+      "lon": -122.4338,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
+    },
+    {
+      "id": "fulton-divisadero",
+      "day": "2026-09-01",
+      "clock": "1:55",
+      "where": "Fulton at Divisadero",
+      "lat": 37.7768,
+      "lon": -122.4381,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
+    },
+    {
+      "id": "california-leon-baker",
+      "day": "2026-09-01",
+      "clock": "2:30",
+      "where": "California between Leon and Baker",
+      "lat": 37.7875,
+      "lon": -122.4446,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
+    },
+    {
+      "id": "broadway-gough",
+      "day": "2026-09-01",
+      "clock": "3:05",
+      "where": "Broadway at Gough",
+      "lat": 37.7952,
+      "lon": -122.4269,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
+    },
+    {
+      "id": "laguna-eddy",
+      "day": "2026-09-01",
+      "clock": "3:40",
+      "where": "Laguna at Eddy",
+      "lat": 37.7821,
+      "lon": -122.4274,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
+    },
+    {
       "id": "lombard-broderick",
       "day": "2026-09-02",
       "clock": "9:37",
@@ -110,131 +174,68 @@
       "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "geary-larkin",
+      "id": "hyde-ofarrell",
       "day": "2026-09-03",
       "clock": "11:00",
-      "where": "Geary near Larkin",
-      "lat": 37.786,
-      "lon": -122.4165,
-      "confidence": "low"
+      "where": "Hyde at O'Farrell",
+      "lat": 37.7855,
+      "lon": -122.4164,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "bush-kearny",
+      "id": "bush-powell",
       "day": "2026-09-03",
       "clock": "11:35",
-      "where": "Bush Street near Kearny",
-      "lat": 37.791,
-      "lon": -122.4045,
-      "confidence": "medium"
+      "where": "Bush at Powell",
+      "lat": 37.7901,
+      "lon": -122.409,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "front-davis-broadway",
+      "id": "embarcadero-folsom",
       "day": "2026-09-03",
       "clock": "1:15",
-      "where": "Front / Davis near Broadway, north waterfront",
-      "lat": 37.7975,
-      "lon": -122.3985,
-      "confidence": "medium"
+      "where": "Embarcadero at Folsom",
+      "lat": 37.791,
+      "lon": -122.3899,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "financial-district-battery",
+      "id": "1st-mission",
       "day": "2026-09-03",
       "clock": "2:07",
-      "where": "Financial District, Battery near Pine",
-      "lat": 37.793,
-      "lon": -122.4,
-      "confidence": "medium"
+      "where": "1st at Mission",
+      "lat": 37.7897,
+      "lon": -122.3974,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "rincon-hill-folsom",
+      "id": "embarcadero-bryant",
       "day": "2026-09-03",
       "clock": "2:40",
-      "where": "Rincon Hill, Folsom near Beale",
-      "lat": 37.789,
-      "lon": -122.3915,
-      "confidence": "medium"
+      "where": "Embarcadero at Bryant",
+      "lat": 37.7868,
+      "lon": -122.3881,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "soma-folsom-2nd",
+      "id": "3rd-folsom",
       "day": "2026-09-03",
       "clock": "3:20",
-      "where": "SoMa, Folsom near 2nd",
-      "lat": 37.7855,
-      "lon": -122.397,
-      "confidence": "medium"
+      "where": "3rd at Folsom",
+      "lat": 37.7837,
+      "lon": -122.3986,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "soma-mission-8th",
+      "id": "howard-6th",
       "day": "2026-09-03",
       "clock": "3:45",
-      "where": "SoMa, Mission near 8th",
-      "lat": 37.779,
-      "lon": -122.413,
-      "confidence": "medium"
-    },
-    {
-      "id": "ashbury-downey",
-      "day": "2026-09-01",
-      "clock": "12:35",
-      "where": "Ashbury at Downey",
-      "lat": 37.769,
-      "lon": -122.445,
+      "where": "Howard at 6th",
+      "lat": 37.7798,
+      "lon": -122.4069,
       "confidence": "operator-named intersection; coordinate approximate to the block",
-      "note": "Named by the operator, not read from the map. The static period detected for this site begins 12:58:38; recording started 12:48, so 12:35 is likely arrival rather than the start of the stationary stretch \u2014 every other 9/1 mark sits within four minutes of its detected start."
-    },
-    {
-      "id": "haight-divisadero",
-      "day": "2026-09-01",
-      "clock": "12:55",
-      "where": "Haight by Divisadero",
-      "lat": 37.7712,
-      "lon": -122.4372,
-      "confidence": "operator-named intersection; coordinate approximate to the block"
-    },
-    {
-      "id": "pierce-haight",
-      "day": "2026-09-01",
-      "clock": "1:25",
-      "where": "Pierce at Haight",
-      "lat": 37.7718,
-      "lon": -122.4338,
-      "confidence": "operator-named intersection; coordinate approximate to the block"
-    },
-    {
-      "id": "fulton-divisadero",
-      "day": "2026-09-01",
-      "clock": "1:55",
-      "where": "Fulton at Divisadero",
-      "lat": 37.7768,
-      "lon": -122.4381,
-      "confidence": "operator-named intersection; coordinate approximate to the block"
-    },
-    {
-      "id": "california-leon-baker",
-      "day": "2026-09-01",
-      "clock": "2:30",
-      "where": "California between Leon and Baker",
-      "lat": 37.7875,
-      "lon": -122.4446,
-      "confidence": "operator-named intersection; coordinate approximate to the block"
-    },
-    {
-      "id": "broadway-gough",
-      "day": "2026-09-01",
-      "clock": "3:05",
-      "where": "Broadway at Gough",
-      "lat": 37.7952,
-      "lon": -122.4269,
-      "confidence": "operator-named intersection; coordinate approximate to the block"
-    },
-    {
-      "id": "laguna-eddy",
-      "day": "2026-09-01",
-      "clock": "3:40",
-      "where": "Laguna at Eddy",
-      "lat": 37.7821,
-      "lon": -122.4274,
-      "confidence": "operator-named intersection; coordinate approximate to the block"
+      "note": "RIP Tess Rothstein 2019-03-08"
     }
   ]
 }

--- a/tools/s2-archive/map-marks.json
+++ b/tools/s2-archive/map-marks.json
@@ -24,8 +24,8 @@
       "day": "2026-09-01",
       "clock": "12:35",
       "where": "Ashbury at Downey",
-      "lat": 37.769,
-      "lon": -122.445,
+      "lat": 37.7638,
+      "lon": -122.4466,
       "confidence": "operator-named intersection; coordinate approximate to the block",
       "note": "Named by the operator, not read from the map. The static period detected for this site begins 12:58:38; recording started 12:48, so 12:35 is likely arrival rather than the start of the stationary stretch \u2014 every other 9/1 mark sits within four minutes of its detected start."
     },

--- a/tools/s2-archive/map-marks.json
+++ b/tools/s2-archive/map-marks.json
@@ -16,7 +16,23 @@
     "is the site's identity everywhere downstream: the site index, the scene",
     "pages and their URLs. It is stable because it is derived from the place,",
     "unlike the positional s01..s23 keys it replaces, which shifted whenever a",
-    "site was added or reclassified."
+    "site was added or reclassified.",
+    "",
+    "Two angles may be given per mark, both in degrees, both optional:",
+    "",
+    "  grid_azimuth_deg  The sensor's zero azimuth measured against the street",
+    "                    grid at this junction. It rotates the ground grid the",
+    "                    viewer draws so the squares line up with the kerbs",
+    "                    instead of with the sensor's mounting. A property of",
+    "                    the street, so it is shared by every site on the same",
+    "                    grid and changes where the grid does.",
+    "",
+    "  north_azimuth_deg The sensor's zero azimuth measured clockwise from true",
+    "                    north. A property of how the tripod was set down, so it",
+    "                    is different at every site even on one street.",
+    "",
+    "They answer different questions and neither can be derived from the other:",
+    "the first makes the scene legible, the second makes it navigable."
   ],
   "marks": [
     {

--- a/tools/s2-archive/map-marks.json
+++ b/tools/s2-archive/map-marks.json
@@ -70,14 +70,6 @@
       "confidence": "medium"
     },
     {
-      "day": "2026-09-01",
-      "clock": "3:05",
-      "where": "near the green/purple boundary; assigned to 9/1 on time, not position",
-      "lat": null,
-      "lon": null,
-      "confidence": "low (day inferred from time, mark sits on the region edge)"
-    },
-    {
       "day": "2026-09-02",
       "clock": "3:25",
       "where": "Nob Hill / Chinatown edge",
@@ -152,7 +144,7 @@
     {
       "day": "2026-09-01",
       "clock": "12:35",
-      "where": "Ashbury at Downey, Haight-Ashbury (given by the operator)",
+      "where": "Ashbury at Downey",
       "lat": 37.769,
       "lon": -122.445,
       "confidence": "operator-named intersection; coordinate approximate to the block",
@@ -160,35 +152,51 @@
     },
     {
       "day": "2026-09-01",
+      "clock": "12:55",
+      "where": "Haight by Divisadero",
+      "lat": 37.7712,
+      "lon": -122.4372,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
+    },
+    {
+      "day": "2026-09-01",
       "clock": "1:25",
-      "where": "Market near Church / Duboce",
-      "lat": 37.769,
-      "lon": -122.429,
-      "confidence": "low"
+      "where": "Pierce at Haight",
+      "lat": 37.7718,
+      "lon": -122.4338,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
       "day": "2026-09-01",
       "clock": "1:55",
-      "where": "NoPa, Fell / Oak near Divisadero",
-      "lat": 37.774,
-      "lon": -122.4375,
-      "confidence": "low"
+      "where": "Fulton at Divisadero",
+      "lat": 37.7768,
+      "lon": -122.4381,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
       "day": "2026-09-01",
       "clock": "2:30",
-      "where": "Laurel Heights / Presidio Heights, California St",
-      "lat": 37.786,
-      "lon": -122.447,
-      "confidence": "low"
+      "where": "California between Leon and Baker",
+      "lat": 37.7875,
+      "lon": -122.4446,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
+    },
+    {
+      "day": "2026-09-01",
+      "clock": "3:05",
+      "where": "Broadway at Gough",
+      "lat": 37.7952,
+      "lon": -122.4269,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
       "day": "2026-09-01",
       "clock": "3:40",
-      "where": "Western Addition, Golden Gate Avenue",
-      "lat": 37.779,
-      "lon": -122.43,
-      "confidence": "low"
+      "where": "Laguna at Eddy",
+      "lat": 37.7821,
+      "lon": -122.4274,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     }
   ]
 }

--- a/tools/s2-archive/map-marks.json
+++ b/tools/s2-archive/map-marks.json
@@ -16,10 +16,10 @@
     {
       "day": "2026-09-02",
       "clock": "9:37",
-      "where": "Cow Hollow, Union Street west of Fillmore",
-      "lat": 37.7975,
-      "lon": -122.436,
-      "confidence": "medium"
+      "where": "Lombard at Broderick",
+      "lat": 37.799,
+      "lon": -122.444,
+      "confidence": "high"
     },
     {
       "day": "2026-09-02",

--- a/tools/s2-archive/map-marks.json
+++ b/tools/s2-archive/map-marks.json
@@ -26,7 +26,7 @@
       "where": "Lombard at Broderick",
       "lat": 37.799,
       "lon": -122.444,
-      "confidence": "high"
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
       "id": "marina-broderick",
@@ -35,70 +35,79 @@
       "where": "Marina Boulevard at Broderick",
       "lat": 37.8053,
       "lon": -122.4455,
-      "confidence": "medium"
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "marina-fillmore",
+      "id": "marina-webster-beach",
       "day": "2026-09-02",
       "clock": "10:28",
-      "where": "Marina Boulevard near Fillmore",
-      "lat": 37.8065,
-      "lon": -122.436,
-      "confidence": "medium"
+      "where": "Marina Boulevard between Webster and Beach",
+      "lat": 37.8057,
+      "lon": -122.4351,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "union-van-ness",
+      "id": "lombard-laguna",
       "day": "2026-09-02",
       "clock": "10:55",
-      "where": "Union Street near Van Ness",
-      "lat": 37.7985,
-      "lon": -122.424,
-      "confidence": "medium"
+      "where": "Lonbard at Laguna",
+      "lat": 37.8004,
+      "lon": -122.4313,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "fisherman-s-wharf",
+      "id": "columbus-north-point",
       "day": "2026-09-02",
       "clock": "11:50",
-      "where": "Fisherman's Wharf, Jefferson Street near Hyde",
-      "lat": 37.807,
-      "lon": -122.42,
-      "confidence": "medium"
+      "where": "Columbus at North Point",
+      "lat": 37.8059,
+      "lon": -122.4181,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "bay-embarcadero",
+      "id": "embarcadero-bay",
       "day": "2026-09-02",
       "clock": "12:36",
-      "where": "Bay Street towards the Embarcadero",
-      "lat": 37.8055,
-      "lon": -122.41,
-      "confidence": "medium"
+      "where": "Embarcadero at Bay",
+      "lat": 37.8067,
+      "lon": -122.4061,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "broadway-telegraph-hill",
+      "id": "columbus-broadway",
       "day": "2026-09-02",
       "clock": "1:15",
-      "where": "Broadway below Telegraph Hill, near Sansome",
-      "lat": 37.798,
-      "lon": -122.402,
-      "confidence": "medium"
+      "where": "Columbus at Broadway",
+      "lat": 37.7978,
+      "lon": -122.4065,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "nob-hill-chinatown",
+      "id": "van-ness-sacramento",
       "day": "2026-09-02",
-      "clock": "3:25",
-      "where": "Nob Hill / Chinatown edge",
-      "lat": null,
-      "lon": null,
-      "confidence": "unread"
+      "clock": "2:25",
+      "where": "van Ness at Sacramento",
+      "lat": 37.7912,
+      "lon": -122.4225,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
-      "id": "van-ness-market",
+      "id": "embarcadero-broadway",
+      "day": "2026-09-02",
+      "clock": "3:20",
+      "where": "Embarcadero at Broadway",
+      "lat": 37.7991,
+      "lon": -122.3976,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
+    },
+    {
+      "id": "franklin-mcallister",
       "day": "2026-09-03",
       "clock": "10:35",
-      "where": "Van Ness near Market, Civic Center",
-      "lat": 37.7755,
-      "lon": -122.419,
-      "confidence": "medium"
+      "where": "Franklin at McAllister",
+      "lat": 37.7798,
+      "lon": -122.4218,
+      "confidence": "operator-named intersection; coordinate approximate to the block"
     },
     {
       "id": "geary-larkin",

--- a/tools/s2-archive/map-marks.json
+++ b/tools/s2-archive/map-marks.json
@@ -151,11 +151,12 @@
     },
     {
       "day": "2026-09-01",
-      "clock": "12:55",
-      "where": "Haight / Divisadero",
-      "lat": 37.7715,
-      "lon": -122.4375,
-      "confidence": "low"
+      "clock": "12:35",
+      "where": "Ashbury at Downey, Haight-Ashbury (given by the operator)",
+      "lat": 37.769,
+      "lon": -122.445,
+      "confidence": "operator-named intersection; coordinate approximate to the block",
+      "note": "Named by the operator, not read from the map. The static period detected for this site begins 12:58:38; recording started 12:48, so 12:35 is likely arrival rather than the start of the stationary stretch \u2014 every other 9/1 mark sits within four minutes of its detected start."
     },
     {
       "day": "2026-09-01",

--- a/tools/s2-archive/map-marks.json
+++ b/tools/s2-archive/map-marks.json
@@ -24,9 +24,9 @@
     {
       "day": "2026-09-02",
       "clock": "10:00",
-      "where": "Marina Boulevard, west end near Baker",
-      "lat": 37.8055,
-      "lon": -122.4445,
+      "where": "Marina Boulevard at Broderick",
+      "lat": 37.8053,
+      "lon": -122.4455,
       "confidence": "medium"
     },
     {

--- a/tools/s2-archive/map-marks.json
+++ b/tools/s2-archive/map-marks.json
@@ -96,7 +96,7 @@
       "id": "marina-broderick",
       "day": "2026-09-02",
       "clock": "10:00",
-      "where": "Marina Boulevard at Broderick",
+      "where": "Marina at Broderick",
       "lat": 37.8053,
       "lon": -122.4455,
       "confidence": "operator-named intersection; coordinate approximate to the block"
@@ -105,7 +105,7 @@
       "id": "marina-webster-beach",
       "day": "2026-09-02",
       "clock": "10:28",
-      "where": "Marina Boulevard between Webster and Beach",
+      "where": "Marina between Webster and Beach",
       "lat": 37.8057,
       "lon": -122.4351,
       "confidence": "operator-named intersection; coordinate approximate to the block"
@@ -114,7 +114,7 @@
       "id": "lombard-laguna",
       "day": "2026-09-02",
       "clock": "10:55",
-      "where": "Lonbard at Laguna",
+      "where": "Lombard at Laguna",
       "lat": 37.8004,
       "lon": -122.4313,
       "confidence": "operator-named intersection; coordinate approximate to the block"

--- a/tools/s2-archive/site-index.json
+++ b/tools/s2-archive/site-index.json
@@ -208,7 +208,7 @@
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "grid_azimuth_deg": null,
     "north_azimuth_deg": null,
-    "published_as": null
+    "published_as": "marina-broderick"
   },
   {
     "id": "marina-webster-beach",

--- a/tools/s2-archive/site-index.json
+++ b/tools/s2-archive/site-index.json
@@ -14,7 +14,7 @@
       "s2-1_20260901131346_00006.pcap"
     ],
     "map_mark": "12:55",
-    "where": "Haight by Divisadero",
+    "where": "Haight at Divisadero",
     "lat": 37.7712,
     "lon": -122.4372,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
@@ -86,7 +86,7 @@
     "lat": 37.7875,
     "lon": -122.4446,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
-    "published_as": null
+    "published_as": "california-leon-baker"
   },
   {
     "id": "broadway-gough",
@@ -108,7 +108,7 @@
     "lat": 37.7952,
     "lon": -122.4269,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
-    "published_as": null
+    "published_as": "broadway-gough"
   },
   {
     "id": "laguna-eddy",
@@ -130,7 +130,7 @@
     "lat": 37.7821,
     "lon": -122.4274,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
-    "published_as": null
+    "published_as": "laguna-eddy"
   },
   {
     "id": "lombard-broderick",
@@ -150,7 +150,7 @@
     "where": "Lombard at Broderick",
     "lat": 37.799,
     "lon": -122.444,
-    "position_confidence": "high",
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
@@ -168,14 +168,14 @@
       "s2_sf_2_20260902101826_00011.pcap"
     ],
     "map_mark": "10:00",
-    "where": "Marina Boulevard at Broderick",
+    "where": "Marina at Broderick",
     "lat": 37.8053,
     "lon": -122.4455,
-    "position_confidence": "medium",
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
-    "id": "marina-fillmore",
+    "id": "marina-webster-beach",
     "site": "s09",
     "day": "2026-09-02",
     "start": "2026-09-02T10:28:27.366603-07:00",
@@ -189,14 +189,14 @@
       "s2_sf_2_20260902104328_00016.pcap"
     ],
     "map_mark": "10:28",
-    "where": "Marina Boulevard near Fillmore",
-    "lat": 37.8065,
-    "lon": -122.436,
-    "position_confidence": "medium",
+    "where": "Marina between Webster and Beach",
+    "lat": 37.8057,
+    "lon": -122.4351,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
-    "id": "union-van-ness",
+    "id": "lombard-laguna",
     "site": "s10",
     "day": "2026-09-02",
     "start": "2026-09-02T10:58:30.258816-07:00",
@@ -214,14 +214,14 @@
       "s2_sf_2_20260902113332_00026.pcap"
     ],
     "map_mark": "10:55",
-    "where": "Union Street near Van Ness",
-    "lat": 37.7985,
-    "lon": -122.424,
-    "position_confidence": "medium",
+    "where": "Lombard at Laguna",
+    "lat": 37.8004,
+    "lon": -122.4313,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": "union-van-ness"
   },
   {
-    "id": "fisherman-s-wharf",
+    "id": "columbus-north-point",
     "site": "s11",
     "day": "2026-09-02",
     "start": "2026-09-02T11:53:34.547768-07:00",
@@ -235,14 +235,14 @@
       "s2_sf_2_20260902120836_00033.pcap"
     ],
     "map_mark": "11:50",
-    "where": "Fisherman's Wharf, Jefferson Street near Hyde",
-    "lat": 37.807,
-    "lon": -122.42,
-    "position_confidence": "medium",
+    "where": "Columbus at North Point",
+    "lat": 37.8059,
+    "lon": -122.4181,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
-    "id": "bay-embarcadero",
+    "id": "embarcadero-bay",
     "site": "s12",
     "day": "2026-09-02",
     "start": "2026-09-02T12:35:17.164539-07:00",
@@ -256,14 +256,14 @@
       "s2_sf_2_20260902125018_00005.pcap"
     ],
     "map_mark": "12:36",
-    "where": "Bay Street towards the Embarcadero",
-    "lat": 37.8055,
-    "lon": -122.41,
-    "position_confidence": "medium",
+    "where": "Embarcadero at Bay",
+    "lat": 37.8067,
+    "lon": -122.4061,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
-    "id": "broadway-telegraph-hill",
+    "id": "columbus-broadway",
     "site": "s13",
     "day": "2026-09-02",
     "start": "2026-09-02T13:20:36.986210-07:00",
@@ -280,14 +280,14 @@
       "s2_sf_3_20260902135038_00008.pcap"
     ],
     "map_mark": "1:15",
-    "where": "Broadway below Telegraph Hill, near Sansome",
-    "lat": 37.798,
-    "lon": -122.402,
-    "position_confidence": "medium",
+    "where": "Columbus at Broadway",
+    "lat": 37.7978,
+    "lon": -122.4065,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": "broadway-telegraph-hill"
   },
   {
-    "id": "nob-hill-chinatown",
+    "id": "embarcadero-broadway",
     "site": "s14",
     "day": "2026-09-02",
     "start": "2026-09-02T15:22:49.666945-07:00",
@@ -301,15 +301,15 @@
       "s2_sf_4_20260902153750_00004.pcap",
       "s2_sf_4_20260902154250_00005.pcap"
     ],
-    "map_mark": "3:25",
-    "where": "Nob Hill / Chinatown edge",
-    "lat": null,
-    "lon": null,
-    "position_confidence": "unread",
+    "map_mark": "3:20",
+    "where": "Embarcadero at Broadway",
+    "lat": 37.7991,
+    "lon": -122.3976,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": "nob-hill-chinatown"
   },
   {
-    "id": "van-ness-market",
+    "id": "franklin-mcallister",
     "site": "s15",
     "day": "2026-09-03",
     "start": "2026-09-03T10:35:52.823348-07:00",
@@ -322,14 +322,14 @@
       "s2_sf_6_20260903104553_00010.pcap"
     ],
     "map_mark": "10:35",
-    "where": "Van Ness near Market, Civic Center",
-    "lat": 37.7755,
-    "lon": -122.419,
-    "position_confidence": "medium",
+    "where": "Franklin at McAllister",
+    "lat": 37.7798,
+    "lon": -122.4218,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
-    "id": "geary-larkin",
+    "id": "hyde-ofarrell",
     "site": "s16",
     "day": "2026-09-03",
     "start": "2026-09-03T11:05:55.344702-07:00",
@@ -343,14 +343,14 @@
       "s2_sf_6_20260903112056_00017.pcap"
     ],
     "map_mark": "11:00",
-    "where": "Geary near Larkin",
-    "lat": 37.786,
-    "lon": -122.4165,
-    "position_confidence": "low",
+    "where": "Hyde at O'Farrell",
+    "lat": 37.7855,
+    "lon": -122.4164,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
-    "id": "bush-kearny",
+    "id": "bush-powell",
     "site": "s17",
     "day": "2026-09-03",
     "start": "2026-09-03T11:35:56.633007-07:00",
@@ -364,10 +364,10 @@
       "s2_sf_6_20260903115058_00023.pcap"
     ],
     "map_mark": "11:35",
-    "where": "Bush Street near Kearny",
-    "lat": 37.791,
-    "lon": -122.4045,
-    "position_confidence": "medium",
+    "where": "Bush at Powell",
+    "lat": 37.7901,
+    "lon": -122.409,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": "bush-kearny"
   },
   {
@@ -393,7 +393,7 @@
     "published_as": "unrecognised-0903-1317"
   },
   {
-    "id": "financial-district-battery",
+    "id": "1st-mission",
     "site": "s19",
     "day": "2026-09-03",
     "start": "2026-09-03T14:10:35.676682-07:00",
@@ -407,14 +407,14 @@
       "s2_sf_8_20260903142536_00008.pcap"
     ],
     "map_mark": "2:07",
-    "where": "Financial District, Battery near Pine",
-    "lat": 37.793,
-    "lon": -122.4,
-    "position_confidence": "medium",
+    "where": "1st at Mission",
+    "lat": 37.7897,
+    "lon": -122.3974,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
-    "id": "rincon-hill-folsom",
+    "id": "embarcadero-bryant",
     "site": "s20",
     "day": "2026-09-03",
     "start": "2026-09-03T14:40:37.854069-07:00",
@@ -429,14 +429,14 @@
       "s2_sf_8_20260903150039_00015.pcap"
     ],
     "map_mark": "2:40",
-    "where": "Rincon Hill, Folsom near Beale",
-    "lat": 37.789,
-    "lon": -122.3915,
-    "position_confidence": "medium",
+    "where": "Embarcadero at Bryant",
+    "lat": 37.7868,
+    "lon": -122.3881,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
-    "id": "soma-folsom-2nd",
+    "id": "unrecognised-0903-1520",
     "site": "s21",
     "day": "2026-09-03",
     "start": "2026-09-03T15:20:41.034128-07:00",
@@ -449,15 +449,15 @@
       "s2_sf_8_20260903153041_00021.pcap",
       "s2_sf_8_20260903153542_00022.pcap"
     ],
-    "map_mark": "3:20",
-    "where": "SoMa, Folsom near 2nd",
-    "lat": 37.7855,
-    "lon": -122.397,
-    "position_confidence": "medium",
+    "map_mark": null,
+    "where": null,
+    "lat": null,
+    "lon": null,
+    "position_confidence": "no mark matched",
     "published_as": null
   },
   {
-    "id": "soma-mission-8th",
+    "id": "howard-6th",
     "site": "s22",
     "day": "2026-09-03",
     "start": "2026-09-03T15:50:43.642189-07:00",
@@ -471,10 +471,10 @@
       "s2_sf_8_20260903160545_00028.pcap"
     ],
     "map_mark": "3:45",
-    "where": "SoMa, Mission near 8th",
-    "lat": 37.779,
-    "lon": -122.413,
-    "position_confidence": "medium",
+    "where": "Howard at 6th",
+    "lat": 37.7798,
+    "lon": -122.4069,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": "soma-mission-8th"
   }
 ]

--- a/tools/s2-archive/site-index.json
+++ b/tools/s2-archive/site-index.json
@@ -1,0 +1,447 @@
+[
+  {
+    "site": "s01",
+    "day": "2026-09-01",
+    "start": "2026-09-01T12:59:22.752867-07:00",
+    "clock": "12:59",
+    "minutes": 19.2,
+    "fragments": 1,
+    "captures": [
+      "s2-1_20260901124845_00001.pcap"
+    ],
+    "map_mark": "12:55",
+    "where": "Haight / Divisadero",
+    "lat": 37.7715,
+    "lon": -122.4375,
+    "position_confidence": "low",
+    "published_as": null
+  },
+  {
+    "site": "s02",
+    "day": "2026-09-01",
+    "start": "2026-09-01T13:27:25.196424-07:00",
+    "clock": "1:27",
+    "minutes": 21.7,
+    "fragments": 1,
+    "captures": [
+      "s2-1_20260901124845_00001.pcap"
+    ],
+    "map_mark": "1:25",
+    "where": "Market near Church / Duboce",
+    "lat": 37.769,
+    "lon": -122.429,
+    "position_confidence": "low",
+    "published_as": null
+  },
+  {
+    "site": "s03",
+    "day": "2026-09-01",
+    "start": "2026-09-01T13:59:33.731163-07:00",
+    "clock": "1:59",
+    "minutes": 20.2,
+    "fragments": 1,
+    "captures": [
+      "s2-1_20260901124845_00001.pcap"
+    ],
+    "map_mark": "1:55",
+    "where": "NoPa, Fell / Oak near Divisadero",
+    "lat": 37.774,
+    "lon": -122.4375,
+    "position_confidence": "low",
+    "published_as": null
+  },
+  {
+    "site": "s04",
+    "day": "2026-09-01",
+    "start": "2026-09-01T14:33:21.213325-07:00",
+    "clock": "2:33",
+    "minutes": 20.9,
+    "fragments": 1,
+    "captures": [
+      "s2-1_20260901124845_00001.pcap"
+    ],
+    "map_mark": "2:30",
+    "where": "Laurel Heights / Presidio Heights, California St",
+    "lat": 37.786,
+    "lon": -122.447,
+    "position_confidence": "low",
+    "published_as": null
+  },
+  {
+    "site": "s05",
+    "day": "2026-09-01",
+    "start": "2026-09-01T15:10:31.646959-07:00",
+    "clock": "3:10",
+    "minutes": 18.6,
+    "fragments": 1,
+    "captures": [
+      "s2-1_20260901124845_00001.pcap"
+    ],
+    "map_mark": "3:05",
+    "where": "near the green/purple boundary; assigned to 9/1 on time, not position",
+    "lat": null,
+    "lon": null,
+    "position_confidence": "low (day inferred from time, mark sits on the region edge)",
+    "published_as": null
+  },
+  {
+    "site": "s06",
+    "day": "2026-09-01",
+    "start": "2026-09-01T15:46:36.580590-07:00",
+    "clock": "3:46",
+    "minutes": 21.8,
+    "fragments": 1,
+    "captures": [
+      "s2-1_20260901124845_00001.pcap"
+    ],
+    "map_mark": "3:40",
+    "where": "Western Addition, Golden Gate Avenue",
+    "lat": 37.779,
+    "lon": -122.43,
+    "position_confidence": "low",
+    "published_as": null
+  },
+  {
+    "site": "s07",
+    "day": "2026-09-02",
+    "start": "2026-09-02T09:38:22.219220-07:00",
+    "clock": "9:38",
+    "minutes": 20.0,
+    "fragments": 4,
+    "captures": [
+      "s2_sf_2_20260902093822_00003.pcap",
+      "s2_sf_2_20260902094322_00004.pcap",
+      "s2_sf_2_20260902094823_00005.pcap",
+      "s2_sf_2_20260902095323_00006.pcap"
+    ],
+    "map_mark": "9:37",
+    "where": "Cow Hollow, Union Street west of Fillmore",
+    "lat": 37.7975,
+    "lon": -122.436,
+    "position_confidence": "medium",
+    "published_as": null
+  },
+  {
+    "site": "s08",
+    "day": "2026-09-02",
+    "start": "2026-09-02T10:03:24.602530-07:00",
+    "clock": "10:03",
+    "minutes": 20.0,
+    "fragments": 4,
+    "captures": [
+      "s2_sf_2_20260902100324_00008.pcap",
+      "s2_sf_2_20260902100825_00009.pcap",
+      "s2_sf_2_20260902101325_00010.pcap",
+      "s2_sf_2_20260902101826_00011.pcap"
+    ],
+    "map_mark": "10:00",
+    "where": "Marina Boulevard, west end near Baker",
+    "lat": 37.8055,
+    "lon": -122.4445,
+    "position_confidence": "medium",
+    "published_as": null
+  },
+  {
+    "site": "s09",
+    "day": "2026-09-02",
+    "start": "2026-09-02T10:28:27.366603-07:00",
+    "clock": "10:28",
+    "minutes": 20.0,
+    "fragments": 4,
+    "captures": [
+      "s2_sf_2_20260902102827_00013.pcap",
+      "s2_sf_2_20260902103327_00014.pcap",
+      "s2_sf_2_20260902103828_00015.pcap",
+      "s2_sf_2_20260902104328_00016.pcap"
+    ],
+    "map_mark": "10:28",
+    "where": "Marina Boulevard near Fillmore",
+    "lat": 37.8065,
+    "lon": -122.436,
+    "position_confidence": "medium",
+    "published_as": null
+  },
+  {
+    "site": "s10",
+    "day": "2026-09-02",
+    "start": "2026-09-02T10:58:30.258816-07:00",
+    "clock": "10:58",
+    "minutes": 38.8,
+    "fragments": 8,
+    "captures": [
+      "s2_sf_2_20260902105830_00019.pcap",
+      "s2_sf_2_20260902110330_00020.pcap",
+      "s2_sf_2_20260902110830_00021.pcap",
+      "s2_sf_2_20260902111331_00022.pcap",
+      "s2_sf_2_20260902111831_00023.pcap",
+      "s2_sf_2_20260902112331_00024.pcap",
+      "s2_sf_2_20260902112832_00025.pcap",
+      "s2_sf_2_20260902113332_00026.pcap"
+    ],
+    "map_mark": "10:55",
+    "where": "Union Street near Van Ness",
+    "lat": 37.7985,
+    "lon": -122.424,
+    "position_confidence": "medium",
+    "published_as": "s2-sf-2"
+  },
+  {
+    "site": "s11",
+    "day": "2026-09-02",
+    "start": "2026-09-02T11:53:34.547768-07:00",
+    "clock": "11:53",
+    "minutes": 18.4,
+    "fragments": 4,
+    "captures": [
+      "s2_sf_2_20260902115334_00030.pcap",
+      "s2_sf_2_20260902115835_00031.pcap",
+      "s2_sf_2_20260902120335_00032.pcap",
+      "s2_sf_2_20260902120836_00033.pcap"
+    ],
+    "map_mark": "11:50",
+    "where": "Fisherman's Wharf, Jefferson Street near Hyde",
+    "lat": 37.807,
+    "lon": -122.42,
+    "position_confidence": "medium",
+    "published_as": null
+  },
+  {
+    "site": "s12",
+    "day": "2026-09-02",
+    "start": "2026-09-02T12:35:17.164539-07:00",
+    "clock": "12:35",
+    "minutes": 15.9,
+    "fragments": 4,
+    "captures": [
+      "s2_sf_2_20260902123517_00002.pcap",
+      "s2_sf_2_20260902124017_00003.pcap",
+      "s2_sf_2_20260902124518_00004.pcap",
+      "s2_sf_2_20260902125018_00005.pcap"
+    ],
+    "map_mark": "12:36",
+    "where": "Bay Street towards the Embarcadero",
+    "lat": 37.8055,
+    "lon": -122.41,
+    "position_confidence": "medium",
+    "published_as": null
+  },
+  {
+    "site": "s13",
+    "day": "2026-09-02",
+    "start": "2026-09-02T13:20:36.986210-07:00",
+    "clock": "1:20",
+    "minutes": 12.7,
+    "fragments": 4,
+    "captures": [
+      "s2_sf_3_20260902132037_00002.pcap",
+      "s2_sf_3_20260902132537_00003.pcap",
+      "s2_sf_3_20260902133037_00004.pcap"
+    ],
+    "map_mark": "1:15",
+    "where": "Broadway below Telegraph Hill, near Sansome",
+    "lat": 37.798,
+    "lon": -122.402,
+    "position_confidence": "medium",
+    "published_as": "broadway-columbus"
+  },
+  {
+    "site": "s14",
+    "day": "2026-09-02",
+    "start": "2026-09-02T13:37:17.485806-07:00",
+    "clock": "1:37",
+    "minutes": 17.2,
+    "fragments": 4,
+    "captures": [
+      "s2_sf_3_20260902133538_00005.pcap",
+      "s2_sf_3_20260902134038_00006.pcap",
+      "s2_sf_3_20260902134538_00007.pcap",
+      "s2_sf_3_20260902135038_00008.pcap"
+    ],
+    "map_mark": null,
+    "where": null,
+    "lat": null,
+    "lon": null,
+    "position_confidence": "no mark matched",
+    "published_as": "s2-sf-3"
+  },
+  {
+    "site": "s15",
+    "day": "2026-09-02",
+    "start": "2026-09-02T15:22:49.666945-07:00",
+    "clock": "3:22",
+    "minutes": 20.2,
+    "fragments": 5,
+    "captures": [
+      "s2_sf_4_20260902152249_00001.pcap",
+      "s2_sf_4_20260902152749_00002.pcap",
+      "s2_sf_4_20260902153250_00003.pcap",
+      "s2_sf_4_20260902153750_00004.pcap",
+      "s2_sf_4_20260902154250_00005.pcap"
+    ],
+    "map_mark": "3:25",
+    "where": "Nob Hill / Chinatown edge",
+    "lat": null,
+    "lon": null,
+    "position_confidence": "unread",
+    "published_as": "s2-sf-4"
+  },
+  {
+    "site": "s16",
+    "day": "2026-09-03",
+    "start": "2026-09-03T10:35:52.823348-07:00",
+    "clock": "10:35",
+    "minutes": 11.7,
+    "fragments": 3,
+    "captures": [
+      "s2_sf_6_20260903103552_00008.pcap",
+      "s2_sf_6_20260903104053_00009.pcap",
+      "s2_sf_6_20260903104553_00010.pcap"
+    ],
+    "map_mark": "10:35",
+    "where": "Van Ness near Market, Civic Center",
+    "lat": 37.7755,
+    "lon": -122.419,
+    "position_confidence": "medium",
+    "published_as": null
+  },
+  {
+    "site": "s17",
+    "day": "2026-09-03",
+    "start": "2026-09-03T11:05:55.344702-07:00",
+    "clock": "11:05",
+    "minutes": 20.0,
+    "fragments": 4,
+    "captures": [
+      "s2_sf_6_20260903110555_00014.pcap",
+      "s2_sf_6_20260903111055_00015.pcap",
+      "s2_sf_6_20260903111555_00016.pcap",
+      "s2_sf_6_20260903112056_00017.pcap"
+    ],
+    "map_mark": "11:00",
+    "where": "Geary near Larkin",
+    "lat": 37.786,
+    "lon": -122.4165,
+    "position_confidence": "low",
+    "published_as": null
+  },
+  {
+    "site": "s18",
+    "day": "2026-09-03",
+    "start": "2026-09-03T11:35:56.633007-07:00",
+    "clock": "11:35",
+    "minutes": 20.0,
+    "fragments": 4,
+    "captures": [
+      "s2_sf_6_20260903113556_00020.pcap",
+      "s2_sf_6_20260903114056_00021.pcap",
+      "s2_sf_6_20260903114557_00022.pcap",
+      "s2_sf_6_20260903115058_00023.pcap"
+    ],
+    "map_mark": "11:35",
+    "where": "Bush Street near Kearny",
+    "lat": 37.791,
+    "lon": -122.4045,
+    "position_confidence": "medium",
+    "published_as": "s2-sf-6"
+  },
+  {
+    "site": "s19",
+    "day": "2026-09-03",
+    "start": "2026-09-03T13:17:48.154812-07:00",
+    "clock": "1:17",
+    "minutes": 20.2,
+    "fragments": 6,
+    "captures": [
+      "s2_sf_7_20260903131748_00001.pcap",
+      "s2_sf_7_20260903132248_00002.pcap",
+      "s2_sf_7_20260903132748_00003.pcap",
+      "s2_sf_7_20260903133249_00004.pcap",
+      "s2_sf_7_20260903133749_00005.pcap"
+    ],
+    "map_mark": null,
+    "where": null,
+    "lat": null,
+    "lon": null,
+    "position_confidence": "no mark matched",
+    "published_as": "s2-sf-7"
+  },
+  {
+    "site": "s20",
+    "day": "2026-09-03",
+    "start": "2026-09-03T14:10:35.676682-07:00",
+    "clock": "2:10",
+    "minutes": 20.0,
+    "fragments": 4,
+    "captures": [
+      "s2_sf_8_20260903141035_00005.pcap",
+      "s2_sf_8_20260903141536_00006.pcap",
+      "s2_sf_8_20260903142036_00007.pcap",
+      "s2_sf_8_20260903142536_00008.pcap"
+    ],
+    "map_mark": "2:07",
+    "where": "Financial District, Battery near Pine",
+    "lat": 37.793,
+    "lon": -122.4,
+    "position_confidence": "medium",
+    "published_as": null
+  },
+  {
+    "site": "s21",
+    "day": "2026-09-03",
+    "start": "2026-09-03T14:40:37.854069-07:00",
+    "clock": "2:40",
+    "minutes": 12.2,
+    "fragments": 3,
+    "captures": [
+      "s2_sf_8_20260903144037_00011.pcap",
+      "s2_sf_8_20260903144538_00012.pcap",
+      "s2_sf_8_20260903145038_00013.pcap"
+    ],
+    "map_mark": "2:40",
+    "where": "Rincon Hill, Folsom near Beale",
+    "lat": 37.789,
+    "lon": -122.3915,
+    "position_confidence": "medium",
+    "published_as": null
+  },
+  {
+    "site": "s22",
+    "day": "2026-09-03",
+    "start": "2026-09-03T15:20:41.034128-07:00",
+    "clock": "3:20",
+    "minutes": 20.0,
+    "fragments": 4,
+    "captures": [
+      "s2_sf_8_20260903152041_00019.pcap",
+      "s2_sf_8_20260903152541_00020.pcap",
+      "s2_sf_8_20260903153041_00021.pcap",
+      "s2_sf_8_20260903153542_00022.pcap"
+    ],
+    "map_mark": "3:20",
+    "where": "SoMa, Folsom near 2nd",
+    "lat": 37.7855,
+    "lon": -122.397,
+    "position_confidence": "medium",
+    "published_as": null
+  },
+  {
+    "site": "s23",
+    "day": "2026-09-03",
+    "start": "2026-09-03T15:50:43.642189-07:00",
+    "clock": "3:50",
+    "minutes": 20.0,
+    "fragments": 4,
+    "captures": [
+      "s2_sf_8_20260903155043_00025.pcap",
+      "s2_sf_8_20260903155544_00026.pcap",
+      "s2_sf_8_20260903160045_00027.pcap",
+      "s2_sf_8_20260903160545_00028.pcap"
+    ],
+    "map_mark": "3:45",
+    "where": "SoMa, Mission near 8th",
+    "lat": 37.779,
+    "lon": -122.413,
+    "position_confidence": "medium",
+    "published_as": "s2-sf-8"
+  }
+]

--- a/tools/s2-archive/site-index.json
+++ b/tools/s2-archive/site-index.json
@@ -12,9 +12,11 @@
     ],
     "map_mark": "12:35",
     "where": "Ashbury at Downey",
-    "lat": 37.769,
-    "lon": -122.445,
+    "lat": 37.7638,
+    "lon": -122.4466,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": null
   },
   {
@@ -36,6 +38,8 @@
     "lat": 37.7712,
     "lon": -122.4372,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": "haight-divisadero"
   },
   {
@@ -59,6 +63,8 @@
     "lat": 37.7718,
     "lon": -122.4338,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": "pierce-haight"
   },
   {
@@ -81,6 +87,8 @@
     "lat": 37.7768,
     "lon": -122.4381,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": "fulton-divisadero"
   },
   {
@@ -104,6 +112,8 @@
     "lat": 37.7875,
     "lon": -122.4446,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": "california-leon-baker"
   },
   {
@@ -126,6 +136,8 @@
     "lat": 37.7952,
     "lon": -122.4269,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": "broadway-gough"
   },
   {
@@ -148,6 +160,8 @@
     "lat": 37.7821,
     "lon": -122.4274,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": "laguna-eddy"
   },
   {
@@ -169,6 +183,8 @@
     "lat": 37.799,
     "lon": -122.444,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": "lombard-broderick"
   },
   {
@@ -190,6 +206,8 @@
     "lat": 37.8053,
     "lon": -122.4455,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": null
   },
   {
@@ -211,6 +229,8 @@
     "lat": 37.8057,
     "lon": -122.4351,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": null
   },
   {
@@ -236,6 +256,8 @@
     "lat": 37.8004,
     "lon": -122.4313,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": "lombard-laguna"
   },
   {
@@ -257,6 +279,8 @@
     "lat": 37.8059,
     "lon": -122.4181,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": null
   },
   {
@@ -278,6 +302,8 @@
     "lat": 37.8067,
     "lon": -122.4061,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": null
   },
   {
@@ -302,6 +328,8 @@
     "lat": 37.7978,
     "lon": -122.4065,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": "columbus-broadway"
   },
   {
@@ -324,6 +352,8 @@
     "lat": 37.7912,
     "lon": -122.4225,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": null
   },
   {
@@ -346,6 +376,8 @@
     "lat": 37.7991,
     "lon": -122.3976,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": "embarcadero-broadway"
   },
   {
@@ -366,6 +398,8 @@
     "lat": 37.7798,
     "lon": -122.4218,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": null
   },
   {
@@ -387,6 +421,8 @@
     "lat": 37.7855,
     "lon": -122.4164,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": null
   },
   {
@@ -408,6 +444,8 @@
     "lat": 37.7901,
     "lon": -122.409,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": "bush-powell"
   },
   {
@@ -430,6 +468,8 @@
     "lat": 37.791,
     "lon": -122.3899,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": "embarcadero-folsom"
   },
   {
@@ -451,6 +491,8 @@
     "lat": 37.7897,
     "lon": -122.3974,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": null
   },
   {
@@ -473,6 +515,8 @@
     "lat": 37.7868,
     "lon": -122.3881,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": null
   },
   {
@@ -494,6 +538,8 @@
     "lat": 37.7837,
     "lon": -122.3986,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": null
   },
   {
@@ -515,6 +561,8 @@
     "lat": 37.7798,
     "lon": -122.4069,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "grid_azimuth_deg": null,
+    "north_azimuth_deg": null,
     "published_as": "howard-6th"
   }
 ]

--- a/tools/s2-archive/site-index.json
+++ b/tools/s2-archive/site-index.json
@@ -7,12 +7,15 @@
     "minutes": 19.2,
     "fragments": 1,
     "captures": [
-      "s2-1_20260901124845_00001.pcap"
+      "s2-1_20260901125845_00003.pcap",
+      "s2-1_20260901130345_00004.pcap",
+      "s2-1_20260901130846_00005.pcap",
+      "s2-1_20260901131346_00006.pcap"
     ],
-    "map_mark": "12:35",
-    "where": "Ashbury at Downey, Haight-Ashbury (given by the operator)",
-    "lat": 37.769,
-    "lon": -122.445,
+    "map_mark": "12:55",
+    "where": "Haight by Divisadero",
+    "lat": 37.7712,
+    "lon": -122.4372,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
@@ -24,13 +27,18 @@
     "minutes": 21.7,
     "fragments": 1,
     "captures": [
-      "s2-1_20260901124845_00001.pcap"
+      "s2-1_20260901132347_00008.pcap",
+      "s2-1_20260901132847_00009.pcap",
+      "s2-1_20260901133348_00010.pcap",
+      "s2-1_20260901133848_00011.pcap",
+      "s2-1_20260901134348_00012.pcap",
+      "s2-1_20260901134849_00013.pcap"
     ],
     "map_mark": "1:25",
-    "where": "Market near Church / Duboce",
-    "lat": 37.769,
-    "lon": -122.429,
-    "position_confidence": "low",
+    "where": "Pierce at Haight",
+    "lat": 37.7718,
+    "lon": -122.4338,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
@@ -41,13 +49,17 @@
     "minutes": 20.2,
     "fragments": 1,
     "captures": [
-      "s2-1_20260901124845_00001.pcap"
+      "s2-1_20260901135850_00015.pcap",
+      "s2-1_20260901140350_00016.pcap",
+      "s2-1_20260901140851_00017.pcap",
+      "s2-1_20260901141351_00018.pcap",
+      "s2-1_20260901141851_00019.pcap"
     ],
     "map_mark": "1:55",
-    "where": "NoPa, Fell / Oak near Divisadero",
-    "lat": 37.774,
-    "lon": -122.4375,
-    "position_confidence": "low",
+    "where": "Fulton at Divisadero",
+    "lat": 37.7768,
+    "lon": -122.4381,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
@@ -58,13 +70,18 @@
     "minutes": 20.9,
     "fragments": 1,
     "captures": [
-      "s2-1_20260901124845_00001.pcap"
+      "s2-1_20260901142853_00021.pcap",
+      "s2-1_20260901143353_00022.pcap",
+      "s2-1_20260901143854_00023.pcap",
+      "s2-1_20260901144354_00024.pcap",
+      "s2-1_20260901144855_00025.pcap",
+      "s2-1_20260901145355_00026.pcap"
     ],
     "map_mark": "2:30",
-    "where": "Laurel Heights / Presidio Heights, California St",
-    "lat": 37.786,
-    "lon": -122.447,
-    "position_confidence": "low",
+    "where": "California between Leon and Baker",
+    "lat": 37.7875,
+    "lon": -122.4446,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
@@ -75,13 +92,17 @@
     "minutes": 18.6,
     "fragments": 1,
     "captures": [
-      "s2-1_20260901124845_00001.pcap"
+      "s2-1_20260901150856_00029.pcap",
+      "s2-1_20260901151357_00030.pcap",
+      "s2-1_20260901151857_00031.pcap",
+      "s2-1_20260901152358_00032.pcap",
+      "s2-1_20260901152858_00033.pcap"
     ],
     "map_mark": "3:05",
-    "where": "near the green/purple boundary; assigned to 9/1 on time, not position",
-    "lat": null,
-    "lon": null,
-    "position_confidence": "low (day inferred from time, mark sits on the region edge)",
+    "where": "Broadway at Gough",
+    "lat": 37.7952,
+    "lon": -122.4269,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
@@ -92,13 +113,17 @@
     "minutes": 21.8,
     "fragments": 1,
     "captures": [
-      "s2-1_20260901124845_00001.pcap"
+      "s2-1_20260901154400_00036.pcap",
+      "s2-1_20260901154900_00037.pcap",
+      "s2-1_20260901155401_00038.pcap",
+      "s2-1_20260901155901_00039.pcap",
+      "s2-1_20260901160401_00040.pcap"
     ],
     "map_mark": "3:40",
-    "where": "Western Addition, Golden Gate Avenue",
-    "lat": 37.779,
-    "lon": -122.43,
-    "position_confidence": "low",
+    "where": "Laguna at Eddy",
+    "lat": 37.7821,
+    "lon": -122.4274,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {

--- a/tools/s2-archive/site-index.json
+++ b/tools/s2-archive/site-index.json
@@ -18,7 +18,7 @@
     "lat": 37.7712,
     "lon": -122.4372,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
-    "published_as": null
+    "published_as": "haight-divisadero"
   },
   {
     "id": "pierce-haight",
@@ -41,7 +41,7 @@
     "lat": 37.7718,
     "lon": -122.4338,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
-    "published_as": null
+    "published_as": "pierce-haight"
   },
   {
     "id": "fulton-divisadero",
@@ -63,7 +63,7 @@
     "lat": 37.7768,
     "lon": -122.4381,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
-    "published_as": null
+    "published_as": "fulton-divisadero"
   },
   {
     "id": "california-leon-baker",
@@ -218,7 +218,7 @@
     "lat": 37.7985,
     "lon": -122.424,
     "position_confidence": "medium",
-    "published_as": "s2-sf-2"
+    "published_as": "union-van-ness"
   },
   {
     "id": "fisherman-s-wharf",
@@ -268,44 +268,27 @@
     "day": "2026-09-02",
     "start": "2026-09-02T13:20:36.986210-07:00",
     "clock": "1:20",
-    "minutes": 12.7,
-    "fragments": 4,
+    "minutes": 33.9,
+    "fragments": 8,
     "captures": [
       "s2_sf_3_20260902132037_00002.pcap",
       "s2_sf_3_20260902132537_00003.pcap",
-      "s2_sf_3_20260902133037_00004.pcap"
+      "s2_sf_3_20260902133037_00004.pcap",
+      "s2_sf_3_20260902133538_00005.pcap",
+      "s2_sf_3_20260902134038_00006.pcap",
+      "s2_sf_3_20260902134538_00007.pcap",
+      "s2_sf_3_20260902135038_00008.pcap"
     ],
     "map_mark": "1:15",
     "where": "Broadway below Telegraph Hill, near Sansome",
     "lat": 37.798,
     "lon": -122.402,
     "position_confidence": "medium",
-    "published_as": "broadway-columbus"
-  },
-  {
-    "id": "unrecognised-0902-1337",
-    "site": "s14",
-    "day": "2026-09-02",
-    "start": "2026-09-02T13:37:17.485806-07:00",
-    "clock": "1:37",
-    "minutes": 17.2,
-    "fragments": 4,
-    "captures": [
-      "s2_sf_3_20260902133538_00005.pcap",
-      "s2_sf_3_20260902134038_00006.pcap",
-      "s2_sf_3_20260902134538_00007.pcap",
-      "s2_sf_3_20260902135038_00008.pcap"
-    ],
-    "map_mark": null,
-    "where": null,
-    "lat": null,
-    "lon": null,
-    "position_confidence": "no mark matched",
-    "published_as": "s2-sf-3"
+    "published_as": "broadway-telegraph-hill"
   },
   {
     "id": "nob-hill-chinatown",
-    "site": "s15",
+    "site": "s14",
     "day": "2026-09-02",
     "start": "2026-09-02T15:22:49.666945-07:00",
     "clock": "3:22",
@@ -323,11 +306,11 @@
     "lat": null,
     "lon": null,
     "position_confidence": "unread",
-    "published_as": "s2-sf-4"
+    "published_as": "nob-hill-chinatown"
   },
   {
     "id": "van-ness-market",
-    "site": "s16",
+    "site": "s15",
     "day": "2026-09-03",
     "start": "2026-09-03T10:35:52.823348-07:00",
     "clock": "10:35",
@@ -347,7 +330,7 @@
   },
   {
     "id": "geary-larkin",
-    "site": "s17",
+    "site": "s16",
     "day": "2026-09-03",
     "start": "2026-09-03T11:05:55.344702-07:00",
     "clock": "11:05",
@@ -368,7 +351,7 @@
   },
   {
     "id": "bush-kearny",
-    "site": "s18",
+    "site": "s17",
     "day": "2026-09-03",
     "start": "2026-09-03T11:35:56.633007-07:00",
     "clock": "11:35",
@@ -385,11 +368,11 @@
     "lat": 37.791,
     "lon": -122.4045,
     "position_confidence": "medium",
-    "published_as": "s2-sf-6"
+    "published_as": "bush-kearny"
   },
   {
     "id": "unrecognised-0903-1317",
-    "site": "s19",
+    "site": "s18",
     "day": "2026-09-03",
     "start": "2026-09-03T13:17:48.154812-07:00",
     "clock": "1:17",
@@ -407,11 +390,11 @@
     "lat": null,
     "lon": null,
     "position_confidence": "no mark matched",
-    "published_as": "s2-sf-7"
+    "published_as": "unrecognised-0903-1317"
   },
   {
     "id": "financial-district-battery",
-    "site": "s20",
+    "site": "s19",
     "day": "2026-09-03",
     "start": "2026-09-03T14:10:35.676682-07:00",
     "clock": "2:10",
@@ -432,16 +415,18 @@
   },
   {
     "id": "rincon-hill-folsom",
-    "site": "s21",
+    "site": "s20",
     "day": "2026-09-03",
     "start": "2026-09-03T14:40:37.854069-07:00",
     "clock": "2:40",
-    "minutes": 12.2,
-    "fragments": 3,
+    "minutes": 22.7,
+    "fragments": 5,
     "captures": [
       "s2_sf_8_20260903144037_00011.pcap",
       "s2_sf_8_20260903144538_00012.pcap",
-      "s2_sf_8_20260903145038_00013.pcap"
+      "s2_sf_8_20260903145038_00013.pcap",
+      "s2_sf_8_20260903145538_00014.pcap",
+      "s2_sf_8_20260903150039_00015.pcap"
     ],
     "map_mark": "2:40",
     "where": "Rincon Hill, Folsom near Beale",
@@ -452,7 +437,7 @@
   },
   {
     "id": "soma-folsom-2nd",
-    "site": "s22",
+    "site": "s21",
     "day": "2026-09-03",
     "start": "2026-09-03T15:20:41.034128-07:00",
     "clock": "3:20",
@@ -473,7 +458,7 @@
   },
   {
     "id": "soma-mission-8th",
-    "site": "s23",
+    "site": "s22",
     "day": "2026-09-03",
     "start": "2026-09-03T15:50:43.642189-07:00",
     "clock": "3:50",
@@ -490,6 +475,6 @@
     "lat": 37.779,
     "lon": -122.413,
     "position_confidence": "medium",
-    "published_as": "s2-sf-8"
+    "published_as": "soma-mission-8th"
   }
 ]

--- a/tools/s2-archive/site-index.json
+++ b/tools/s2-archive/site-index.json
@@ -140,10 +140,10 @@
       "s2_sf_2_20260902095323_00006.pcap"
     ],
     "map_mark": "9:37",
-    "where": "Cow Hollow, Union Street west of Fillmore",
-    "lat": 37.7975,
-    "lon": -122.436,
-    "position_confidence": "medium",
+    "where": "Lombard at Broderick",
+    "lat": 37.799,
+    "lon": -122.444,
+    "position_confidence": "high",
     "published_as": null
   },
   {
@@ -160,9 +160,9 @@
       "s2_sf_2_20260902101826_00011.pcap"
     ],
     "map_mark": "10:00",
-    "where": "Marina Boulevard, west end near Baker",
-    "lat": 37.8055,
-    "lon": -122.4445,
+    "where": "Marina Boulevard at Broderick",
+    "lat": 37.8053,
+    "lon": -122.4455,
     "position_confidence": "medium",
     "published_as": null
   },

--- a/tools/s2-archive/site-index.json
+++ b/tools/s2-archive/site-index.json
@@ -218,7 +218,7 @@
     "lat": 37.8004,
     "lon": -122.4313,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
-    "published_as": "union-van-ness"
+    "published_as": "lombard-laguna"
   },
   {
     "id": "columbus-north-point",
@@ -284,7 +284,7 @@
     "lat": 37.7978,
     "lon": -122.4065,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
-    "published_as": "broadway-telegraph-hill"
+    "published_as": "columbus-broadway"
   },
   {
     "id": "embarcadero-broadway",
@@ -306,7 +306,7 @@
     "lat": 37.7991,
     "lon": -122.3976,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
-    "published_as": "nob-hill-chinatown"
+    "published_as": "embarcadero-broadway"
   },
   {
     "id": "franklin-mcallister",
@@ -368,7 +368,7 @@
     "lat": 37.7901,
     "lon": -122.409,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
-    "published_as": "bush-kearny"
+    "published_as": "bush-powell"
   },
   {
     "id": "unrecognised-0903-1317",
@@ -475,6 +475,6 @@
     "lat": 37.7798,
     "lon": -122.4069,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
-    "published_as": "soma-mission-8th"
+    "published_as": "howard-6th"
   }
 ]

--- a/tools/s2-archive/site-index.json
+++ b/tools/s2-archive/site-index.json
@@ -305,8 +305,30 @@
     "published_as": "columbus-broadway"
   },
   {
-    "id": "embarcadero-broadway",
+    "id": "van-ness-sacramento",
     "site": "s15",
+    "day": "2026-09-02",
+    "start": "2026-09-02T14:27:14.678856-07:00",
+    "clock": "2:27",
+    "minutes": 21.1,
+    "fragments": 3,
+    "captures": [
+      "s2_sf_4_20260902142714_00001.pcap",
+      "s2_sf_4_20260902143214_00002.pcap",
+      "s2_sf_4_20260902143715_00003.pcap",
+      "s2_sf_4_20260902144215_00004.pcap",
+      "s2_sf_4_20260902144716_00005.pcap"
+    ],
+    "map_mark": "2:25",
+    "where": "van Ness at Sacramento",
+    "lat": 37.7912,
+    "lon": -122.4225,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "published_as": null
+  },
+  {
+    "id": "embarcadero-broadway",
+    "site": "s16",
     "day": "2026-09-02",
     "start": "2026-09-02T15:22:49.666945-07:00",
     "clock": "3:22",
@@ -328,7 +350,7 @@
   },
   {
     "id": "franklin-mcallister",
-    "site": "s16",
+    "site": "s17",
     "day": "2026-09-03",
     "start": "2026-09-03T10:35:52.823348-07:00",
     "clock": "10:35",
@@ -348,7 +370,7 @@
   },
   {
     "id": "hyde-ofarrell",
-    "site": "s17",
+    "site": "s18",
     "day": "2026-09-03",
     "start": "2026-09-03T11:05:55.344702-07:00",
     "clock": "11:05",
@@ -369,7 +391,7 @@
   },
   {
     "id": "bush-powell",
-    "site": "s18",
+    "site": "s19",
     "day": "2026-09-03",
     "start": "2026-09-03T11:35:56.633007-07:00",
     "clock": "11:35",
@@ -390,7 +412,7 @@
   },
   {
     "id": "embarcadero-folsom",
-    "site": "s19",
+    "site": "s20",
     "day": "2026-09-03",
     "start": "2026-09-03T13:17:48.154812-07:00",
     "clock": "1:17",
@@ -412,7 +434,7 @@
   },
   {
     "id": "1st-mission",
-    "site": "s20",
+    "site": "s21",
     "day": "2026-09-03",
     "start": "2026-09-03T14:10:35.676682-07:00",
     "clock": "2:10",
@@ -433,7 +455,7 @@
   },
   {
     "id": "embarcadero-bryant",
-    "site": "s21",
+    "site": "s22",
     "day": "2026-09-03",
     "start": "2026-09-03T14:40:37.854069-07:00",
     "clock": "2:40",
@@ -455,7 +477,7 @@
   },
   {
     "id": "3rd-folsom",
-    "site": "s22",
+    "site": "s23",
     "day": "2026-09-03",
     "start": "2026-09-03T15:20:41.034128-07:00",
     "clock": "3:20",
@@ -476,7 +498,7 @@
   },
   {
     "id": "howard-6th",
-    "site": "s23",
+    "site": "s24",
     "day": "2026-09-03",
     "start": "2026-09-03T15:50:43.642189-07:00",
     "clock": "3:50",

--- a/tools/s2-archive/site-index.json
+++ b/tools/s2-archive/site-index.json
@@ -1,7 +1,25 @@
 [
   {
-    "id": "haight-divisadero",
+    "id": "ashbury-downey",
     "site": "s01",
+    "day": "2026-09-01",
+    "start": "2026-09-01T12:25:33.019394-07:00",
+    "clock": "12:25",
+    "minutes": 20.5,
+    "fragments": 1,
+    "captures": [
+      "s2-sf-0.pcapng"
+    ],
+    "map_mark": "12:35",
+    "where": "Ashbury at Downey",
+    "lat": 37.769,
+    "lon": -122.445,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "published_as": null
+  },
+  {
+    "id": "haight-divisadero",
+    "site": "s02",
     "day": "2026-09-01",
     "start": "2026-09-01T12:59:22.752867-07:00",
     "clock": "12:59",
@@ -22,7 +40,7 @@
   },
   {
     "id": "pierce-haight",
-    "site": "s02",
+    "site": "s03",
     "day": "2026-09-01",
     "start": "2026-09-01T13:27:25.196424-07:00",
     "clock": "1:27",
@@ -45,7 +63,7 @@
   },
   {
     "id": "fulton-divisadero",
-    "site": "s03",
+    "site": "s04",
     "day": "2026-09-01",
     "start": "2026-09-01T13:59:33.731163-07:00",
     "clock": "1:59",
@@ -67,7 +85,7 @@
   },
   {
     "id": "california-leon-baker",
-    "site": "s04",
+    "site": "s05",
     "day": "2026-09-01",
     "start": "2026-09-01T14:33:21.213325-07:00",
     "clock": "2:33",
@@ -90,7 +108,7 @@
   },
   {
     "id": "broadway-gough",
-    "site": "s05",
+    "site": "s06",
     "day": "2026-09-01",
     "start": "2026-09-01T15:10:31.646959-07:00",
     "clock": "3:10",
@@ -112,7 +130,7 @@
   },
   {
     "id": "laguna-eddy",
-    "site": "s06",
+    "site": "s07",
     "day": "2026-09-01",
     "start": "2026-09-01T15:46:36.580590-07:00",
     "clock": "3:46",
@@ -134,7 +152,7 @@
   },
   {
     "id": "lombard-broderick",
-    "site": "s07",
+    "site": "s08",
     "day": "2026-09-02",
     "start": "2026-09-02T09:38:22.219220-07:00",
     "clock": "9:38",
@@ -151,11 +169,11 @@
     "lat": 37.799,
     "lon": -122.444,
     "position_confidence": "operator-named intersection; coordinate approximate to the block",
-    "published_as": null
+    "published_as": "lombard-broderick"
   },
   {
     "id": "marina-broderick",
-    "site": "s08",
+    "site": "s09",
     "day": "2026-09-02",
     "start": "2026-09-02T10:03:24.602530-07:00",
     "clock": "10:03",
@@ -176,7 +194,7 @@
   },
   {
     "id": "marina-webster-beach",
-    "site": "s09",
+    "site": "s10",
     "day": "2026-09-02",
     "start": "2026-09-02T10:28:27.366603-07:00",
     "clock": "10:28",
@@ -197,7 +215,7 @@
   },
   {
     "id": "lombard-laguna",
-    "site": "s10",
+    "site": "s11",
     "day": "2026-09-02",
     "start": "2026-09-02T10:58:30.258816-07:00",
     "clock": "10:58",
@@ -222,7 +240,7 @@
   },
   {
     "id": "columbus-north-point",
-    "site": "s11",
+    "site": "s12",
     "day": "2026-09-02",
     "start": "2026-09-02T11:53:34.547768-07:00",
     "clock": "11:53",
@@ -243,7 +261,7 @@
   },
   {
     "id": "embarcadero-bay",
-    "site": "s12",
+    "site": "s13",
     "day": "2026-09-02",
     "start": "2026-09-02T12:35:17.164539-07:00",
     "clock": "12:35",
@@ -264,7 +282,7 @@
   },
   {
     "id": "columbus-broadway",
-    "site": "s13",
+    "site": "s14",
     "day": "2026-09-02",
     "start": "2026-09-02T13:20:36.986210-07:00",
     "clock": "1:20",
@@ -288,7 +306,7 @@
   },
   {
     "id": "embarcadero-broadway",
-    "site": "s14",
+    "site": "s15",
     "day": "2026-09-02",
     "start": "2026-09-02T15:22:49.666945-07:00",
     "clock": "3:22",
@@ -310,7 +328,7 @@
   },
   {
     "id": "franklin-mcallister",
-    "site": "s15",
+    "site": "s16",
     "day": "2026-09-03",
     "start": "2026-09-03T10:35:52.823348-07:00",
     "clock": "10:35",
@@ -330,7 +348,7 @@
   },
   {
     "id": "hyde-ofarrell",
-    "site": "s16",
+    "site": "s17",
     "day": "2026-09-03",
     "start": "2026-09-03T11:05:55.344702-07:00",
     "clock": "11:05",
@@ -351,7 +369,7 @@
   },
   {
     "id": "bush-powell",
-    "site": "s17",
+    "site": "s18",
     "day": "2026-09-03",
     "start": "2026-09-03T11:35:56.633007-07:00",
     "clock": "11:35",
@@ -371,8 +389,8 @@
     "published_as": "bush-powell"
   },
   {
-    "id": "unrecognised-0903-1317",
-    "site": "s18",
+    "id": "embarcadero-folsom",
+    "site": "s19",
     "day": "2026-09-03",
     "start": "2026-09-03T13:17:48.154812-07:00",
     "clock": "1:17",
@@ -385,16 +403,16 @@
       "s2_sf_7_20260903133249_00004.pcap",
       "s2_sf_7_20260903133749_00005.pcap"
     ],
-    "map_mark": null,
-    "where": null,
-    "lat": null,
-    "lon": null,
-    "position_confidence": "no mark matched",
-    "published_as": "unrecognised-0903-1317"
+    "map_mark": "1:15",
+    "where": "Embarcadero at Folsom",
+    "lat": 37.791,
+    "lon": -122.3899,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
+    "published_as": "embarcadero-folsom"
   },
   {
     "id": "1st-mission",
-    "site": "s19",
+    "site": "s20",
     "day": "2026-09-03",
     "start": "2026-09-03T14:10:35.676682-07:00",
     "clock": "2:10",
@@ -415,7 +433,7 @@
   },
   {
     "id": "embarcadero-bryant",
-    "site": "s20",
+    "site": "s21",
     "day": "2026-09-03",
     "start": "2026-09-03T14:40:37.854069-07:00",
     "clock": "2:40",
@@ -436,8 +454,8 @@
     "published_as": null
   },
   {
-    "id": "unrecognised-0903-1520",
-    "site": "s21",
+    "id": "3rd-folsom",
+    "site": "s22",
     "day": "2026-09-03",
     "start": "2026-09-03T15:20:41.034128-07:00",
     "clock": "3:20",
@@ -449,16 +467,16 @@
       "s2_sf_8_20260903153041_00021.pcap",
       "s2_sf_8_20260903153542_00022.pcap"
     ],
-    "map_mark": null,
-    "where": null,
-    "lat": null,
-    "lon": null,
-    "position_confidence": "no mark matched",
+    "map_mark": "3:20",
+    "where": "3rd at Folsom",
+    "lat": 37.7837,
+    "lon": -122.3986,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {
     "id": "howard-6th",
-    "site": "s22",
+    "site": "s23",
     "day": "2026-09-03",
     "start": "2026-09-03T15:50:43.642189-07:00",
     "clock": "3:50",

--- a/tools/s2-archive/site-index.json
+++ b/tools/s2-archive/site-index.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "haight-divisadero",
     "site": "s01",
     "day": "2026-09-01",
     "start": "2026-09-01T12:59:22.752867-07:00",
@@ -20,6 +21,7 @@
     "published_as": null
   },
   {
+    "id": "pierce-haight",
     "site": "s02",
     "day": "2026-09-01",
     "start": "2026-09-01T13:27:25.196424-07:00",
@@ -42,6 +44,7 @@
     "published_as": null
   },
   {
+    "id": "fulton-divisadero",
     "site": "s03",
     "day": "2026-09-01",
     "start": "2026-09-01T13:59:33.731163-07:00",
@@ -63,6 +66,7 @@
     "published_as": null
   },
   {
+    "id": "california-leon-baker",
     "site": "s04",
     "day": "2026-09-01",
     "start": "2026-09-01T14:33:21.213325-07:00",
@@ -85,6 +89,7 @@
     "published_as": null
   },
   {
+    "id": "broadway-gough",
     "site": "s05",
     "day": "2026-09-01",
     "start": "2026-09-01T15:10:31.646959-07:00",
@@ -106,6 +111,7 @@
     "published_as": null
   },
   {
+    "id": "laguna-eddy",
     "site": "s06",
     "day": "2026-09-01",
     "start": "2026-09-01T15:46:36.580590-07:00",
@@ -127,6 +133,7 @@
     "published_as": null
   },
   {
+    "id": "lombard-broderick",
     "site": "s07",
     "day": "2026-09-02",
     "start": "2026-09-02T09:38:22.219220-07:00",
@@ -147,6 +154,7 @@
     "published_as": null
   },
   {
+    "id": "marina-broderick",
     "site": "s08",
     "day": "2026-09-02",
     "start": "2026-09-02T10:03:24.602530-07:00",
@@ -167,6 +175,7 @@
     "published_as": null
   },
   {
+    "id": "marina-fillmore",
     "site": "s09",
     "day": "2026-09-02",
     "start": "2026-09-02T10:28:27.366603-07:00",
@@ -187,6 +196,7 @@
     "published_as": null
   },
   {
+    "id": "union-van-ness",
     "site": "s10",
     "day": "2026-09-02",
     "start": "2026-09-02T10:58:30.258816-07:00",
@@ -211,6 +221,7 @@
     "published_as": "s2-sf-2"
   },
   {
+    "id": "fisherman-s-wharf",
     "site": "s11",
     "day": "2026-09-02",
     "start": "2026-09-02T11:53:34.547768-07:00",
@@ -231,6 +242,7 @@
     "published_as": null
   },
   {
+    "id": "bay-embarcadero",
     "site": "s12",
     "day": "2026-09-02",
     "start": "2026-09-02T12:35:17.164539-07:00",
@@ -251,6 +263,7 @@
     "published_as": null
   },
   {
+    "id": "broadway-telegraph-hill",
     "site": "s13",
     "day": "2026-09-02",
     "start": "2026-09-02T13:20:36.986210-07:00",
@@ -270,6 +283,7 @@
     "published_as": "broadway-columbus"
   },
   {
+    "id": "unrecognised-0902-1337",
     "site": "s14",
     "day": "2026-09-02",
     "start": "2026-09-02T13:37:17.485806-07:00",
@@ -290,6 +304,7 @@
     "published_as": "s2-sf-3"
   },
   {
+    "id": "nob-hill-chinatown",
     "site": "s15",
     "day": "2026-09-02",
     "start": "2026-09-02T15:22:49.666945-07:00",
@@ -311,6 +326,7 @@
     "published_as": "s2-sf-4"
   },
   {
+    "id": "van-ness-market",
     "site": "s16",
     "day": "2026-09-03",
     "start": "2026-09-03T10:35:52.823348-07:00",
@@ -330,6 +346,7 @@
     "published_as": null
   },
   {
+    "id": "geary-larkin",
     "site": "s17",
     "day": "2026-09-03",
     "start": "2026-09-03T11:05:55.344702-07:00",
@@ -350,6 +367,7 @@
     "published_as": null
   },
   {
+    "id": "bush-kearny",
     "site": "s18",
     "day": "2026-09-03",
     "start": "2026-09-03T11:35:56.633007-07:00",
@@ -370,6 +388,7 @@
     "published_as": "s2-sf-6"
   },
   {
+    "id": "unrecognised-0903-1317",
     "site": "s19",
     "day": "2026-09-03",
     "start": "2026-09-03T13:17:48.154812-07:00",
@@ -391,6 +410,7 @@
     "published_as": "s2-sf-7"
   },
   {
+    "id": "financial-district-battery",
     "site": "s20",
     "day": "2026-09-03",
     "start": "2026-09-03T14:10:35.676682-07:00",
@@ -411,6 +431,7 @@
     "published_as": null
   },
   {
+    "id": "rincon-hill-folsom",
     "site": "s21",
     "day": "2026-09-03",
     "start": "2026-09-03T14:40:37.854069-07:00",
@@ -430,6 +451,7 @@
     "published_as": null
   },
   {
+    "id": "soma-folsom-2nd",
     "site": "s22",
     "day": "2026-09-03",
     "start": "2026-09-03T15:20:41.034128-07:00",
@@ -450,6 +472,7 @@
     "published_as": null
   },
   {
+    "id": "soma-mission-8th",
     "site": "s23",
     "day": "2026-09-03",
     "start": "2026-09-03T15:50:43.642189-07:00",

--- a/tools/s2-archive/site-index.json
+++ b/tools/s2-archive/site-index.json
@@ -9,11 +9,11 @@
     "captures": [
       "s2-1_20260901124845_00001.pcap"
     ],
-    "map_mark": "12:55",
-    "where": "Haight / Divisadero",
-    "lat": 37.7715,
-    "lon": -122.4375,
-    "position_confidence": "low",
+    "map_mark": "12:35",
+    "where": "Ashbury at Downey, Haight-Ashbury (given by the operator)",
+    "lat": 37.769,
+    "lon": -122.445,
+    "position_confidence": "operator-named intersection; coordinate approximate to the block",
     "published_as": null
   },
   {

--- a/tools/s2-archive/site-joins.json
+++ b/tools/s2-archive/site-joins.json
@@ -1,0 +1,28 @@
+{
+  "comment": [
+    "Spans the operator asserts are one site, which the classifier reads as",
+    "several. Hand-authored, like map-marks.json, and for the same reason: it",
+    "records something only the person who was there can know.",
+    "",
+    "The case this exists for is a nudged tripod. A sensor on a camping chair",
+    "gets bumped; it moves a few centimetres and then stands still again. The",
+    "classifier sees the displacement and calls it motion, which is what it",
+    "calls a car driving between junctions, and a twenty-minute survey is",
+    "discarded as three short stops.",
+    "",
+    "This is a stopgap and should be deleted. Whether a nudge belongs inside a",
+    "static period is a question about the background model's tolerance, not",
+    "about a list of exceptions: see",
+    "docs/plans/static-sensor-nudge-tolerance-plan.md. Every entry here is a",
+    "case the classifier ought to get right on its own."
+  ],
+  "joins": [
+    {
+      "day": "2026-09-02",
+      "from": "14:27:14",
+      "to": "14:48:23",
+      "why": "Tripod stood on a camping chair and was nudged a few times. The sensor moved centimetres, not streets; the operator was parked at this junction throughout.",
+      "asserted_by": "operator"
+    }
+  ]
+}


### PR DESCRIPTION
# Purpose

Extract the archive inventory and classification investigations from #569 so they can be reviewed before the complete Captures workflow merges. This PR inventories 24 recorded sites using existing analysis output, operator field marks, and explicit assertions that nudged-tripod fragments belong to one visit.

# Changes

- Add offline site-index construction, capture attribution, filename-based deployment inspection, field marks, and operator site joins. Preserve stable site IDs and optional orientation measurements.
- Include the generated archive snapshot and investigations covering continuous classification, parameter tuning, tripod nudges, and future Go ingestion.
- Keep the production capture index, database migrations, replay engine, operator UI, and `publish-scenes.py` in #569. The public scene catalogue is a separate, unfinished extraction and is not included here.
- Clarify that branch-only replay capabilities are not shipped and `published_as` records development-checkout observations, not publication on main.

# Validation

- Both Python files parse; snapshot checks pass for 24 distinct sites, 24 distinct field marks, valid positions, nonempty capture lists, and one operator join.
- Rebuilt from the local archive into a temporary output without altering the batch job: all 24 sites and all non-publication fields match the committed snapshot. Fourteen `published_as` values become null because the standalone main-based checkout lacks those catalogue exports; this is documented.
- Targeted Markdown formatting, relative links, header metadata, British spelling, and `git diff --check` pass. Basic commit hooks pass; the broad Markdown formatter was skipped after formatting these five documents directly.

The archive lives at `/Volumes/lidar/lidar/s2` and is not bundled. Rebuilding requires those local inputs. No production replay or website build is claimed by these checks.

# Checklist

- [x] Uses British English spelling/wording where applicable.
- [ ] Design is confirmed and aligns with `DESIGN.md`.
- [ ] Any maths/derived values are valid and up to date.
- [ ] Version has been bumped where required.
- [x] Documentation is up to date for this extraction boundary.
- [ ] `README.md` is up to date.
- [ ] `docs/DEVLOG.md` is up to date.
